### PR TITLE
[Zellic] 8 The is_empty methods always return false

### DIFF
--- a/g16ckt/src/gadgets/bn254/fq12.rs
+++ b/g16ckt/src/gadgets/bn254/fq12.rs
@@ -68,7 +68,7 @@ impl Fq12 {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.len() == 0
     }
 
     pub fn new_constant(v: ark_bn254::Fq12) -> Fq12 {

--- a/g16ckt/src/gadgets/bn254/fq2.rs
+++ b/g16ckt/src/gadgets/bn254/fq2.rs
@@ -84,7 +84,7 @@ impl Fq2 {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.len() == 0
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &WireId> {

--- a/g16ckt/src/gadgets/bn254/fq6.rs
+++ b/g16ckt/src/gadgets/bn254/fq6.rs
@@ -519,7 +519,7 @@ impl Fq6 {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.len() == 0
     }
 }
 


### PR DESCRIPTION
Fixes #12 