### PR TITLE
[Zellic] 4.2 Remediation strategy for missing input validation

### DIFF
--- a/g16ckt/examples/pairing_gate_counts.rs
+++ b/g16ckt/examples/pairing_gate_counts.rs
@@ -211,7 +211,8 @@ fn main() {
             move || {
                 run_and_print("test_ell_montgomery", inputs, move |ctx, w| {
                     let f0 = fq12_one_const();
-                    let coeffs = pairing::ell_coeffs_montgomery(ctx, &w.g2);
+                    // ignoring _is_valid because this function is used only for benchmarking over valid inputs
+                    let (coeffs, _is_valid) = pairing::ell_coeffs_montgomery(ctx, &w.g2);
                     // Take first coeff triple and evaluate once
                     let c = coeffs.into_iter().next().unwrap();
                     let _f1 = pairing::ell_montgomery(ctx, &f0, &c, &w.g1);

--- a/g16ckt/src/gadgets/bn254/fq.rs
+++ b/g16ckt/src/gadgets/bn254/fq.rs
@@ -304,7 +304,8 @@ pub(super) mod tests {
     use std::{array, iter};
 
     use ark_ff::AdditiveGroup;
-    use rand::Rng;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha20Rng;
     use test_log::test;
     use tracing::trace;
 
@@ -678,6 +679,29 @@ pub(super) mod tests {
             });
 
         assert_eq!(result.output_value.value, expected_c);
+    }
+
+    #[test]
+    fn test_fq_sqrt_montgomery_roundtrip() {
+        let mut rng = ChaCha20Rng::seed_from_u64(42);
+        for _ in 0..5 {
+            let aa_v = Fq::random(&mut rng);
+            let sqrt_exists = aa_v.sqrt().is_some();
+
+            let aa_montgomery = Fq::as_montgomery(aa_v);
+            let input = FqInput::new([aa_montgomery]);
+
+            let result =
+                CircuitBuilder::streaming_execute::<_, _, FqOutput>(input, 10_000, |ctx, input| {
+                    let [aa_wire] = input;
+                    let sqrt = Fq::sqrt_montgomery(ctx, aa_wire);
+                    Fq::square_montgomery(ctx, &sqrt)
+                });
+
+            let calc_aa_montgomery = result.output_value.value;
+
+            assert_eq!(sqrt_exists, calc_aa_montgomery == aa_montgomery);
+        }
     }
 
     #[test]

--- a/g16ckt/src/gadgets/bn254/fq.rs
+++ b/g16ckt/src/gadgets/bn254/fq.rs
@@ -297,6 +297,15 @@ impl Fq {
             &BigUint::from_str(Self::MODULUS_ADD_1_DIV_4).unwrap(),
         )
     }
+
+    /// Return a>b in standard form given inputs in montgomery form
+    pub fn greater_than<C: CircuitContext>(circuit: &mut C, a: &Fq, b: &Fq) -> WireId {
+        // First convert the inputs 'a' and 'b' back to standard form
+        let a = Fq::mul_by_constant_montgomery(circuit, a, &ark_bn254::Fq::ONE);
+        let b = Fq::mul_by_constant_montgomery(circuit, b, &ark_bn254::Fq::ONE);
+        // only now perform comparison
+        bigint::greater_than(circuit, &a, &b)
+    }
 }
 
 #[cfg(test)]

--- a/g16ckt/src/gadgets/bn254/fq2.rs
+++ b/g16ckt/src/gadgets/bn254/fq2.rs
@@ -15,7 +15,8 @@ use crate::{
     CircuitContext, Gate, WireId,
     circuit::WiresObject,
     gadgets::{
-        bigint::{BigIntWires, select},
+        basic,
+        bigint::{self, BigIntWires, select},
         bn254::{fp254impl::Fp254Impl, fq::Fq},
     },
 };
@@ -443,6 +444,14 @@ impl Fq2 {
         let c1_final = Fq::mul_montgomery(circuit, &c0_inv, &c1_half); // c1 / (2 * c0)
 
         Fq2::from_components(c0_final, c1_final)
+    }
+
+    /// Return a>b in standard form given inputs in montgomery form
+    pub fn greater_than<C: CircuitContext>(circuit: &mut C, a: &Fq2, b: &Fq2) -> WireId {
+        let c1_equal = bigint::equal(circuit, a.c1(), b.c1());
+        let c1_greater = Fq::greater_than(circuit, a.c1(), b.c1());
+        let c0_greater = Fq::greater_than(circuit, a.c0(), b.c0());
+        basic::selector(circuit, c0_greater, c1_greater, c1_equal)
     }
 }
 

--- a/g16ckt/src/gadgets/bn254/g1.rs
+++ b/g16ckt/src/gadgets/bn254/g1.rs
@@ -6,7 +6,7 @@ use circuit_component_macro::component;
 
 use crate::{
     CircuitContext, WireId,
-    circuit::{FromWires, WiresArity, WiresObject},
+    circuit::{FromWires, TRUE_WIRE, WiresArity, WiresObject},
     gadgets::{
         bigint::{self, BigIntWires},
         bn254::{fp254impl::Fp254Impl, fq::Fq, fr::Fr},
@@ -413,32 +413,77 @@ impl G1Projective {
     }
 
     /// Deserialize into G1Projective from its 32 byte serialized bit representation.
+    // Follows arkworks implementation here:
+    // https://github.com/arkworks-rs/algebra/blob/v0.5.0/ec/src/models/short_weierstrass/mod.rs#L145
     pub fn deserialize_checked<C: CircuitContext>(
         circuit: &mut C,
         serialized_bits: [WireId; 32 * 8],
     ) -> DecompressedG1Wires {
         let (x_m, flag) = {
-            let byte_arr: Vec<[WireId; 8]> = serialized_bits
-                .chunks(8)
-                .map(|c| c.try_into().expect("chunk is exactly 8"))
-                .collect();
-            let bit_arr: Vec<WireId> = byte_arr.into_iter().flatten().collect();
-            let (num, flag) = bit_arr.split_at(Fq::N_BITS);
+            let (num, flag) = serialized_bits.split_at(Fq::N_BITS);
             let a = Fq(BigIntWires { bits: num.to_vec() });
-
+            // convert input field element in standard form into montgomery form
             let r = Fq::as_montgomery(ark_bn254::Fq::ONE);
             let a_mont = Fq::mul_by_constant_montgomery(circuit, &a, &r.square());
-
-            (a_mont, flag.to_vec())
+            // flag_0 is lsb, flag 1 is msb
+            (a_mont, [flag[0], flag[1]])
         };
 
-        let y_neg_flag = circuit.issue_wire();
-        circuit.add_gate(crate::Gate {
-            wire_a: flag[0],
-            wire_b: flag[1],
-            wire_c: y_neg_flag,
-            gate_type: crate::GateType::Or,
-        });
+        // Part 1: Extract Flags
+
+        let is_y_positive = {
+            // In arkworks, given:
+            // const Y_IS_POSITIVE: u8 = 0;
+            let flag_or = circuit.issue_wire();
+            circuit.add_gate(crate::Gate {
+                wire_a: flag[0],
+                wire_b: flag[1],
+                wire_c: flag_or,
+                gate_type: crate::GateType::Or,
+            });
+            let flag_nor = circuit.issue_wire();
+            circuit.add_gate(crate::Gate {
+                wire_a: flag_or,
+                wire_b: TRUE_WIRE,
+                wire_c: flag_nor,
+                gate_type: crate::GateType::Xor,
+            });
+            flag_nor
+        };
+
+        let is_y_negative = {
+            // In arkworks, given:
+            // const Y_IS_NEGATIVE: u8 = 1 << 7;
+            let tmp0 = circuit.issue_wire();
+            circuit.add_gate(crate::Gate {
+                wire_a: flag[0],
+                wire_b: TRUE_WIRE,
+                wire_c: tmp0,
+                gate_type: crate::GateType::Xor,
+            });
+            let tmp1 = circuit.issue_wire();
+            circuit.add_gate(crate::Gate {
+                wire_a: flag[1],
+                wire_b: tmp0,
+                wire_c: tmp1,
+                gate_type: crate::GateType::And,
+            });
+            tmp1
+        };
+
+        // rest of the flags (11 and 01) represent identity and None, so are invalid flags
+        let flags_is_valid = {
+            let tmp0 = circuit.issue_wire();
+            circuit.add_gate(crate::Gate {
+                wire_a: is_y_positive,
+                wire_b: is_y_negative,
+                wire_c: tmp0,
+                gate_type: crate::GateType::Or,
+            });
+            tmp0
+        };
+
+        // Part 2: compute (X, Y, Z)
 
         // rhs = x^3 + b (Montgomery domain)
         let x2 = Fq::square_montgomery(circuit, &x_m);
@@ -449,22 +494,36 @@ impl G1Projective {
         // sy = sqrt(rhs) in Montgomery domain
         let sy = Fq::sqrt_montgomery(circuit, &rhs);
         let rhs_is_qr = {
+            // if sqrt doesn't exist, sy squared is not equal to the original number
+            // this means (x, y) doesn't yield a point in the curve
             let sy_sy = Fq::square_montgomery(circuit, &sy);
             bigint::equal(circuit, &sy_sy, &rhs)
         };
 
+        // analogous to get_point_from_x_unchecked
         let sy_neg = Fq::neg(circuit, &sy);
-
         let sy_neg_greater = Fq::greater_than(circuit, &sy_neg, &sy);
         let tsy = bigint::select(circuit, &sy, &sy_neg, sy_neg_greater);
         let tsy_neg = bigint::select(circuit, &sy_neg, &sy, sy_neg_greater);
-
-        let y_bits = bigint::select(circuit, &tsy_neg, &tsy, y_neg_flag);
+        let y_bits = bigint::select(circuit, &tsy_neg, &tsy, is_y_negative);
         let y = Fq(y_bits);
 
         // z = 1 in Montgomery
         let one_m = Fq::as_montgomery(ark_bn254::Fq::ONE);
         let z = Fq::new_constant(&one_m).expect("const one mont");
+
+        let input_is_valid = {
+            // Input is invalid if input is not a valid point in the curve or deserialization error
+            // valid only if both crieterion is met
+            let tmp0 = circuit.issue_wire();
+            circuit.add_gate(crate::Gate {
+                wire_a: rhs_is_qr,
+                wire_b: flags_is_valid,
+                wire_c: tmp0,
+                gate_type: crate::GateType::And,
+            });
+            tmp0
+        };
 
         DecompressedG1Wires {
             point: G1Projective {
@@ -472,11 +531,12 @@ impl G1Projective {
                 y,
                 z,
             },
-            is_valid: rhs_is_qr,
+            is_valid: input_is_valid,
         }
     }
 }
 
+/// Analogous to Option<G1Projective> where is_valid acts similar to is_some()
 #[derive(Debug, Clone)]
 pub struct DecompressedG1Wires {
     pub point: G1Projective,

--- a/g16ckt/src/gadgets/bn254/g1.rs
+++ b/g16ckt/src/gadgets/bn254/g1.rs
@@ -412,6 +412,22 @@ impl G1Projective {
         }
     }
 
+    /// check whether or not the point is on the curve or not
+    /// checks y^2=x^3+3z^6 (Jacobian projective coordinates)
+    #[component]
+    pub fn is_on_curve<C: CircuitContext>(circuit: &mut C, p: &G1Projective) -> WireId {
+        let x2 = Fq::square_montgomery(circuit, &p.x);
+        let x3 = Fq::mul_montgomery(circuit, &p.x, &x2);
+        let y2 = Fq::square_montgomery(circuit, &p.y);
+        let z2 = Fq::square_montgomery(circuit, &p.z);
+        let z4 = Fq::square_montgomery(circuit, &z2);
+        let z6 = Fq::mul_montgomery(circuit, &z2, &z4);
+        let triplez6 = Fq::triple(circuit, &z6); // because ark_bn254::g1::Config::COEFF_B is 3
+        let temp = Fq::add(circuit, &x3, &triplez6);
+        let should_be_zero = Fq::sub(circuit, &y2, &temp);
+        bigint::equal_zero(circuit, &should_be_zero.0)
+    }
+
     /// Deserialize into G1Projective from its 32 byte serialized bit representation.
     // Follows arkworks implementation here:
     // https://github.com/arkworks-rs/algebra/blob/v0.5.0/ec/src/models/short_weierstrass/mod.rs#L145
@@ -1084,5 +1100,38 @@ mod tests {
             assert_eq!(calc_is_valid, ref_is_valid);
             assert_eq!(calc_is_valid, pt.is_on_curve());
         }
+    }
+
+    #[test]
+    fn test_g1_is_on_curve() {
+        let mut rng = ChaCha20Rng::seed_from_u64(111);
+        let r = ark_bn254::G1Projective::rand(&mut rng);
+        let ref_is_on_curve = r.into_affine().is_on_curve();
+        let input = G1Input {
+            points: [G1Projective::as_montgomery(r)],
+        };
+        let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
+            CircuitBuilder::streaming_execute(input, 10_000, |ctx, wires| {
+                let is_on_curve = G1Projective::is_on_curve(ctx, &wires.points[0]);
+                vec![is_on_curve]
+            });
+        assert_eq!(out.output_value[0], ref_is_on_curve);
+
+        // not a point on curve
+        let r = ark_bn254::G1Projective::new_unchecked(
+            ark_bn254::Fq::rand(&mut rng),
+            ark_bn254::Fq::rand(&mut rng),
+            ark_bn254::Fq::rand(&mut rng),
+        );
+        let input = G1Input {
+            points: [G1Projective::as_montgomery(r)],
+        };
+        let ref_is_on_curve = r.into_affine().is_on_curve();
+        let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
+            CircuitBuilder::streaming_execute(input, 10_000, |ctx, wires| {
+                let is_on_curve = G1Projective::is_on_curve(ctx, &wires.points[0]);
+                vec![is_on_curve]
+            });
+        assert_eq!(out.output_value[0], ref_is_on_curve);
     }
 }

--- a/g16ckt/src/gadgets/bn254/g1.rs
+++ b/g16ckt/src/gadgets/bn254/g1.rs
@@ -1,8 +1,9 @@
 use std::{cmp::min, collections::HashMap, iter};
 
 use ark_ec::short_weierstrass::SWCurveConfig;
-use ark_ff::{Field, Zero};
+use ark_ff::{Field, PrimeField, Zero};
 use circuit_component_macro::component;
+use num_bigint::BigUint;
 
 use crate::{
     CircuitContext, WireId,
@@ -435,14 +436,17 @@ impl G1Projective {
         circuit: &mut C,
         serialized_bits: [WireId; 32 * 8],
     ) -> DecompressedG1Wires {
-        let (x_m, flag) = {
+        let (x_m, is_x_m_valid, flag) = {
             let (num, flag) = serialized_bits.split_at(Fq::N_BITS);
-            let a = Fq(BigIntWires { bits: num.to_vec() });
+            let a = BigIntWires { bits: num.to_vec() };
+            // check BigUint is a valid fq
+            let r: BigUint = ark_bn254::Fq::MODULUS.into();
+            let valid_fq = bigint::less_than_constant(circuit, &a, &r);
             // convert input field element in standard form into montgomery form
             let r = Fq::as_montgomery(ark_bn254::Fq::ONE);
-            let a_mont = Fq::mul_by_constant_montgomery(circuit, &a, &r.square());
+            let a_mont = Fq::mul_by_constant_montgomery(circuit, &Fq(a), &r.square());
             // flag_0 is lsb, flag 1 is msb
-            (a_mont, [flag[0], flag[1]])
+            (a_mont, valid_fq, [flag[0], flag[1]])
         };
 
         // Part 1: Extract Flags
@@ -532,13 +536,20 @@ impl G1Projective {
             // Input is invalid if input is not a valid point in the curve or deserialization error
             // valid only if both crieterion is met
             let tmp0 = circuit.issue_wire();
+            let tmp1 = circuit.issue_wire();
             circuit.add_gate(crate::Gate {
                 wire_a: rhs_is_qr,
                 wire_b: flags_is_valid,
                 wire_c: tmp0,
                 gate_type: crate::GateType::And,
             });
-            tmp0
+            circuit.add_gate(crate::Gate {
+                wire_a: tmp0,
+                wire_b: is_x_m_valid,
+                wire_c: tmp1,
+                gate_type: crate::GateType::And,
+            });
+            tmp1
         };
 
         DecompressedG1Wires {

--- a/g16ckt/src/gadgets/bn254/g1.rs
+++ b/g16ckt/src/gadgets/bn254/g1.rs
@@ -1,12 +1,16 @@
 use std::{cmp::min, collections::HashMap, iter};
 
-use ark_ff::Zero;
+use ark_ec::short_weierstrass::SWCurveConfig;
+use ark_ff::{Field, Zero};
 use circuit_component_macro::component;
 
 use crate::{
     CircuitContext, WireId,
     circuit::{FromWires, WiresArity, WiresObject},
-    gadgets::bn254::{fp254impl::Fp254Impl, fq::Fq, fr::Fr},
+    gadgets::{
+        bigint::{self, BigIntWires},
+        bn254::{fp254impl::Fp254Impl, fq::Fq, fr::Fr},
+    },
 };
 
 #[derive(Clone, Debug)]
@@ -407,6 +411,70 @@ impl G1Projective {
             z: p.z.clone(),
         }
     }
+
+    /// Deserialize into G1Projective from its 32 byte serialized bit representation.
+    pub fn deserialize_checked<C: CircuitContext>(
+        circuit: &mut C,
+        serialized_bits: [WireId; 32 * 8],
+    ) -> DecompressedG1Wires {
+        let (x_m, flag) = {
+            let byte_arr: Vec<[WireId; 8]> = serialized_bits
+                .chunks(8)
+                .map(|c| c.try_into().expect("chunk is exactly 8"))
+                .collect();
+            let bit_arr: Vec<WireId> = byte_arr.into_iter().flatten().collect();
+            let (num, flag) = bit_arr.split_at(Fq::N_BITS);
+            let a = Fq(BigIntWires { bits: num.to_vec() });
+
+            let r = Fq::as_montgomery(ark_bn254::Fq::ONE);
+            let a_mont = Fq::mul_by_constant_montgomery(circuit, &a, &r.square());
+
+            (a_mont, flag.to_vec())
+        };
+
+        let y_neg_flag = circuit.issue_wire();
+        circuit.add_gate(crate::Gate {
+            wire_a: flag[0],
+            wire_b: flag[1],
+            wire_c: y_neg_flag,
+            gate_type: crate::GateType::Or,
+        });
+
+        // rhs = x^3 + b (Montgomery domain)
+        let x2 = Fq::square_montgomery(circuit, &x_m);
+        let x3 = Fq::mul_montgomery(circuit, &x2, &x_m);
+        let b_m = Fq::as_montgomery(ark_bn254::g1::Config::COEFF_B);
+        let rhs = Fq::add_constant(circuit, &x3, &b_m);
+
+        // sy = sqrt(rhs) in Montgomery domain
+        let sy = Fq::sqrt_montgomery(circuit, &rhs);
+        let rhs_is_qr = {
+            let sy_sy = Fq::square_montgomery(circuit, &sy);
+            bigint::equal(circuit, &sy_sy, &rhs)
+        };
+
+        let sy_neg = Fq::neg(circuit, &sy);
+
+        let sy_neg_greater = Fq::greater_than(circuit, &sy_neg, &sy);
+        let tsy = bigint::select(circuit, &sy, &sy_neg, sy_neg_greater);
+        let tsy_neg = bigint::select(circuit, &sy_neg, &sy, sy_neg_greater);
+
+        let y_bits = bigint::select(circuit, &tsy_neg, &tsy, y_neg_flag);
+        let y = Fq(y_bits);
+
+        // z = 1 in Montgomery
+        let one_m = Fq::as_montgomery(ark_bn254::Fq::ONE);
+        let z = Fq::new_constant(&one_m).expect("const one mont");
+
+        DecompressedG1Wires {
+            point: G1Projective {
+                x: x_m.clone(),
+                y,
+                z,
+            },
+            is_valid: rhs_is_qr,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -447,8 +515,9 @@ impl WiresArity for DecompressedG1Wires {
 
 #[cfg(test)]
 mod tests {
-    use ark_ec::{CurveGroup, VariableBaseMSM};
+    use ark_ec::{CurveGroup, PrimeGroup, VariableBaseMSM};
     use ark_ff::UniformRand;
+    use ark_serialize::CanonicalSerialize;
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha20Rng;
 
@@ -886,5 +955,74 @@ mod tests {
 
         let actual_result = G1Projective::from_bits_unchecked(result.output_value.clone());
         assert_eq!(actual_result, neg_a_mont);
+    }
+
+    #[test]
+    fn test_g1_compress_decompress_matches() {
+        let mut rng = ChaCha20Rng::seed_from_u64(111);
+        let r = ark_bn254::Fr::rand(&mut rng);
+        let p = (ark_bn254::G1Projective::generator() * r).into_affine();
+
+        let mut p_bytes = Vec::new();
+        p.serialize_compressed(&mut p_bytes).unwrap();
+        let input: Vec<bool> = p_bytes
+            .iter()
+            .flat_map(|&b| (0..8).map(move |i| ((b >> i) & 1) == 1))
+            .collect();
+        let input: [bool; 256] = input.try_into().unwrap();
+
+        let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
+            CircuitBuilder::streaming_execute(input, 10_000, |ctx, wires| {
+                let res = G1Projective::deserialize_checked(ctx, *wires);
+                let dec = res.point;
+
+                let exp = G1Projective::as_montgomery(p.into());
+                let x_ok = Fq::equal_constant(ctx, &dec.x, &exp.x);
+                let z_ok = Fq::equal_constant(ctx, &dec.z, &exp.z);
+                // Compare y up to sign by checking y^2 equality
+                let y_sq = Fq::square_montgomery(ctx, &dec.y);
+                let exp_y_std = Fq::from_montgomery(exp.y);
+                let exp_y_sq_m = Fq::as_montgomery(exp_y_std.square());
+                let y_ok = Fq::equal_constant(ctx, &y_sq, &exp_y_sq_m);
+                vec![x_ok, y_ok, z_ok, res.is_valid]
+            });
+
+        assert!(out.output_value.iter().all(|&b| b));
+    }
+
+    #[test]
+    fn test_g1_decompress_failure() {
+        let mut rng = ChaCha20Rng::seed_from_u64(112);
+        for _ in 0..5 {
+            // sufficient sample size to sample both valid and invalid points
+            let x = ark_bn254::Fq::rand(&mut rng);
+            let a1 = ark_bn254::Fq::sqrt(&((x * x * x) + ark_bn254::Fq::from(3)));
+            let (y, ref_is_valid) = if let Some(a1) = a1 {
+                // if it is possible to take square root, you have found correct y,
+                (a1, true)
+            } else {
+                // else generate some random value
+                (ark_bn254::Fq::rand(&mut rng), false)
+            };
+            let pt = ark_bn254::G1Affine::new_unchecked(x, y);
+
+            let mut p_bytes = Vec::new();
+            pt.serialize_compressed(&mut p_bytes).unwrap();
+            let input: Vec<bool> = p_bytes
+                .iter()
+                .flat_map(|&b| (0..8).map(move |i| ((b >> i) & 1) == 1))
+                .collect();
+            let input: [bool; 256] = input.try_into().unwrap();
+
+            let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
+                CircuitBuilder::streaming_execute(input, 10_000, |ctx, wires| {
+                    let dec = G1Projective::deserialize_checked(ctx, *wires);
+                    vec![dec.is_valid]
+                });
+            let calc_is_valid = out.output_value[0];
+
+            assert_eq!(calc_is_valid, ref_is_valid);
+            assert_eq!(calc_is_valid, pt.is_on_curve());
+        }
     }
 }

--- a/g16ckt/src/gadgets/bn254/g2.rs
+++ b/g16ckt/src/gadgets/bn254/g2.rs
@@ -5,7 +5,7 @@ use circuit_component_macro::component;
 
 use crate::{
     CircuitContext, WireId,
-    circuit::{FromWires, WiresObject},
+    circuit::{FromWires, WiresArity, WiresObject},
     gadgets::{
         bigint::Error,
         bn254::{fp254impl::Fp254Impl, fq::Fq, fq2::Fq2, fr::Fr},
@@ -526,16 +526,53 @@ impl G2Projective {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct DecompressedG2Wires {
+    pub point: G2Projective,
+    pub is_valid: WireId,
+}
+
+impl WiresObject for DecompressedG2Wires {
+    fn to_wires_vec(&self) -> Vec<WireId> {
+        let mut wires = Vec::new();
+        wires.extend(self.point.to_wires_vec());
+        wires.push(self.is_valid);
+        wires
+    }
+
+    fn clone_from(&self, mut wire_gen: &mut impl FnMut() -> WireId) -> Self {
+        Self {
+            point: self.point.clone_from(&mut wire_gen),
+            is_valid: wire_gen(),
+        }
+    }
+}
+
+impl FromWires for DecompressedG2Wires {
+    fn from_wires(wires: &[WireId]) -> Option<Self> {
+        assert_eq!(wires.len(), DecompressedG2Wires::ARITY);
+        Some(Self {
+            point: G2Projective::from_wires(&wires[0..G2Projective::N_BITS])?,
+            is_valid: wires[G2Projective::N_BITS],
+        })
+    }
+}
+
+impl WiresArity for DecompressedG2Wires {
+    const ARITY: usize = G2Projective::N_BITS + 1;
+}
+
 #[cfg(test)]
 mod tests {
     use ark_ec::{CurveGroup, VariableBaseMSM};
-    use ark_ff::UniformRand;
+    use ark_ff::{Field, UniformRand};
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha20Rng;
 
     use super::*;
     use crate::{
         circuit::{CircuitBuilder, CircuitInput, EncodeInput, modes::CircuitMode},
+        gadgets::bn254::pairing::double_in_place,
         test_utils::trng,
     };
 
@@ -690,6 +727,33 @@ mod tests {
 
         let actual_result = G2Projective::from_bits_unchecked(result.output_value.clone());
         assert_eq!(actual_result, c_mont);
+    }
+
+    #[test]
+    fn test_double_in_place() {
+        use ark_ec::CurveGroup;
+
+        let mut rng = ChaCha20Rng::seed_from_u64(42);
+
+        // a is in Jacobian
+        let a = ark_bn254::G2Projective::rand(&mut rng);
+
+        // Jacobian doubling via library, then to affine
+        let b_aff = (a + a).into_affine();
+
+        // Start from affine (x,y,1) but run HOMOGENEOUS doubling
+        let a_aff = a.into_affine();
+        let mut r = ark_bn254::G2Projective::new(a_aff.x, a_aff.y, ark_bn254::Fq2::ONE);
+        double_in_place(&mut r); // r = (X,Y,Z) in HOMOGENEOUS
+
+        // Convert HOMOGENEOUS -> JACOBIAN expected by arkworks:
+        r.x *= r.z; // X' = X*Z
+        let z2 = r.z.square();
+        r.y *= z2; // Y' = Y*Z^2
+        // Z' = Z
+
+        let r_aff = r.into_affine(); // now safe to normalize
+        assert_eq!(b_aff, r_aff);
     }
 
     #[test]

--- a/g16ckt/src/gadgets/bn254/g2.rs
+++ b/g16ckt/src/gadgets/bn254/g2.rs
@@ -1,8 +1,9 @@
 use std::{cmp::min, collections::HashMap, iter::zip};
 
 use ark_ec::short_weierstrass::SWCurveConfig;
-use ark_ff::{AdditiveGroup, Field, Zero};
+use ark_ff::{AdditiveGroup, Field, PrimeField, Zero};
 use circuit_component_macro::component;
+use num_bigint::BigUint;
 
 use crate::{
     CircuitContext, WireId,
@@ -564,29 +565,40 @@ impl G2Projective {
         circuit: &mut C,
         serialized_bits: [WireId; 64 * 8],
     ) -> DecompressedG2Wires {
-        let (x, flag) = {
+        let (x, is_x_valid, flag) = {
             let (num1, num2, flag) = (
                 &serialized_bits[0..Fq::N_BITS],
                 &serialized_bits[32 * 8..32 * 8 + Fq::N_BITS],
                 &serialized_bits[32 * 8 + Fq::N_BITS..],
             );
-            let a = Fq2([
-                Fq(BigIntWires {
-                    bits: num1.to_vec(),
-                }),
-                Fq(BigIntWires {
-                    bits: num2.to_vec(),
-                }),
-            ]);
+            let a0 = BigIntWires {
+                bits: num1.to_vec(),
+            };
+            let a1 = BigIntWires {
+                bits: num2.to_vec(),
+            };
+            let r: BigUint = ark_bn254::Fq::MODULUS.into();
+            let valid_fq = {
+                let valid_a0 = bigint::less_than_constant(circuit, &a0, &r);
+                let valid_a1 = bigint::less_than_constant(circuit, &a1, &r);
+                let valid_fq = circuit.issue_wire();
+                circuit.add_gate(crate::Gate {
+                    wire_a: valid_a0,
+                    wire_b: valid_a1,
+                    wire_c: valid_fq,
+                    gate_type: crate::GateType::And,
+                });
+                valid_fq
+            };
 
             // convert input field element in standard form into montgomery form
             let r = Fq::as_montgomery(ark_bn254::Fq::ONE);
-            let a_mont_x = Fq::mul_by_constant_montgomery(circuit, a.c0(), &r.square());
+            let a_mont_x = Fq::mul_by_constant_montgomery(circuit, &Fq(a0), &r.square());
             let r = Fq::as_montgomery(ark_bn254::Fq::ONE);
-            let a_mont_y = Fq::mul_by_constant_montgomery(circuit, a.c1(), &r.square());
+            let a_mont_y = Fq::mul_by_constant_montgomery(circuit, &Fq(a1), &r.square());
 
             // flag_0 is lsb, flag 1 is msb
-            (Fq2([a_mont_x, a_mont_y]), [flag[0], flag[1]])
+            (Fq2([a_mont_x, a_mont_y]), valid_fq, [flag[0], flag[1]])
         };
 
         // Part 1: Extract Flags
@@ -696,13 +708,20 @@ impl G2Projective {
             // Input is invalid if input is not a valid point in the curve or deserialization error
             // valid only if both crieterion is met
             let tmp0 = circuit.issue_wire();
+            let tmp1 = circuit.issue_wire();
             circuit.add_gate(crate::Gate {
                 wire_a: rhs_is_qr,
                 wire_b: flags_is_valid,
                 wire_c: tmp0,
                 gate_type: crate::GateType::And,
             });
-            tmp0
+            circuit.add_gate(crate::Gate {
+                wire_a: tmp0,
+                wire_b: is_x_valid,
+                wire_c: tmp1,
+                gate_type: crate::GateType::And,
+            });
+            tmp1
         };
 
         DecompressedG2Wires {

--- a/g16ckt/src/gadgets/bn254/g2.rs
+++ b/g16ckt/src/gadgets/bn254/g2.rs
@@ -6,7 +6,7 @@ use circuit_component_macro::component;
 
 use crate::{
     CircuitContext, WireId,
-    circuit::{FromWires, WiresArity, WiresObject},
+    circuit::{FromWires, TRUE_WIRE, WiresArity, WiresObject},
     gadgets::{
         bigint::{self, BigIntWires, Error},
         bn254::{fp254impl::Fp254Impl, fq::Fq, fq2::Fq2, fr::Fr},
@@ -526,22 +526,18 @@ impl G2Projective {
         }
     }
 
-    /// Deserialize into G1Projective from its 32 byte serialized bit representation.
+    /// Deserialize into G2Projective from its 64 byte serialized bit representation.
+    // Follows arkworks implementation here:
+    // https://github.com/arkworks-rs/algebra/blob/v0.5.0/ec/src/models/short_weierstrass/mod.rs#L145
     pub fn deserialize_checked<C: CircuitContext>(
         circuit: &mut C,
         serialized_bits: [WireId; 64 * 8],
     ) -> DecompressedG2Wires {
         let (x, flag) = {
-            let byte_arr: Vec<[WireId; 8]> = serialized_bits
-                .chunks(8)
-                .map(|c| c.try_into().expect("chunk is exactly 8"))
-                .collect();
-            // flatten byte_array
-            let bit_arr: Vec<WireId> = byte_arr.into_iter().flatten().collect();
             let (num1, num2, flag) = (
-                &bit_arr[0..Fq::N_BITS],
-                &bit_arr[32 * 8..32 * 8 + Fq::N_BITS],
-                &bit_arr[32 * 8 + Fq::N_BITS..],
+                &serialized_bits[0..Fq::N_BITS],
+                &serialized_bits[32 * 8..32 * 8 + Fq::N_BITS],
+                &serialized_bits[32 * 8 + Fq::N_BITS..],
             );
             let a = Fq2([
                 Fq(BigIntWires {
@@ -552,26 +548,74 @@ impl G2Projective {
                 }),
             ]);
 
+            // convert input field element in standard form into montgomery form
             let r = Fq::as_montgomery(ark_bn254::Fq::ONE);
             let a_mont_x = Fq::mul_by_constant_montgomery(circuit, a.c0(), &r.square());
             let r = Fq::as_montgomery(ark_bn254::Fq::ONE);
             let a_mont_y = Fq::mul_by_constant_montgomery(circuit, a.c1(), &r.square());
 
-            (Fq2([a_mont_x, a_mont_y]), flag.to_vec())
+            // flag_0 is lsb, flag 1 is msb
+            (Fq2([a_mont_x, a_mont_y]), [flag[0], flag[1]])
         };
 
-        let y_neg_flag = circuit.issue_wire();
-        circuit.add_gate(crate::Gate {
-            wire_a: flag[0],
-            wire_b: flag[1],
-            wire_c: y_neg_flag,
-            gate_type: crate::GateType::Or,
-        });
+        // Part 1: Extract Flags
+
+        let is_y_positive = {
+            // In arkworks, given:
+            // const Y_IS_POSITIVE: u8 = 0;
+            let flag_or = circuit.issue_wire();
+            circuit.add_gate(crate::Gate {
+                wire_a: flag[0],
+                wire_b: flag[1],
+                wire_c: flag_or,
+                gate_type: crate::GateType::Or,
+            });
+            let flag_nor = circuit.issue_wire();
+            circuit.add_gate(crate::Gate {
+                wire_a: flag_or,
+                wire_b: TRUE_WIRE,
+                wire_c: flag_nor,
+                gate_type: crate::GateType::Xor,
+            });
+            flag_nor
+        };
+
+        let is_y_negative = {
+            // In arkworks, given:
+            // const Y_IS_NEGATIVE: u8 = 1 << 7;
+            let tmp0 = circuit.issue_wire();
+            circuit.add_gate(crate::Gate {
+                wire_a: flag[0],
+                wire_b: TRUE_WIRE,
+                wire_c: tmp0,
+                gate_type: crate::GateType::Xor,
+            });
+            let tmp1 = circuit.issue_wire();
+            circuit.add_gate(crate::Gate {
+                wire_a: flag[1],
+                wire_b: tmp0,
+                wire_c: tmp1,
+                gate_type: crate::GateType::And,
+            });
+            tmp1
+        };
+
+        // rest of the flags (11 and 01) represent identity and None, so are invalid flags
+        let flags_is_valid = {
+            let tmp0 = circuit.issue_wire();
+            circuit.add_gate(crate::Gate {
+                wire_a: is_y_positive,
+                wire_b: is_y_negative,
+                wire_c: tmp0,
+                gate_type: crate::GateType::Or,
+            });
+            tmp0
+        };
+
+        // Part 2: compute (X, Y, Z)
 
         let x2 = Fq2::square_montgomery(circuit, &x);
-
         let x3 = Fq2::mul_montgomery(circuit, &x2, &x);
-
         let y2 = Fq2::add_constant(
             circuit,
             &x3,
@@ -580,7 +624,8 @@ impl G2Projective {
 
         let y = Fq2::sqrt_general_montgomery(circuit, &y2);
         let rhs_is_qr = {
-            // check if y * y == y2 to ensure rhs was a quadratic residue to begin with
+            // check if y * y == y2 to ensure rhs was a quadratic residue to begin with,
+            // if it was not, then it means (x,y) is not a point on the curve
             let y_y = Fq2::square_montgomery(circuit, &y);
 
             let match_c0 = bigint::equal(circuit, y2.c0(), y_y.c0());
@@ -595,8 +640,8 @@ impl G2Projective {
             match_c0_and_c1
         };
 
+        // analogous to get_point_from_x_unchecked
         let neg_y = Fq2::neg(circuit, y.clone());
-
         let y_neg_greater = Fq2::greater_than(circuit, &neg_y, &y);
         let tsy = {
             let tsy_c0 = bigint::select(circuit, y.c0(), neg_y.c0(), y_neg_greater);
@@ -609,12 +654,25 @@ impl G2Projective {
             Fq2([Fq(tsy_neg_c0), Fq(tsy_neg_c1)])
         };
 
-        let final_y_0 = bigint::select(circuit, tsy_neg.c0(), tsy.c0(), y_neg_flag);
-        let final_y_1 = bigint::select(circuit, tsy_neg.c1(), tsy.c1(), y_neg_flag);
+        let final_y_0 = bigint::select(circuit, tsy_neg.c0(), tsy.c0(), is_y_negative);
+        let final_y_1 = bigint::select(circuit, tsy_neg.c1(), tsy.c1(), is_y_negative);
 
         // z = 1 in Montgomery
         let one_m = Fq::as_montgomery(ark_bn254::Fq::ONE);
         let zero_m = Fq::as_montgomery(ark_bn254::Fq::ZERO);
+
+        let input_is_valid = {
+            // Input is invalid if input is not a valid point in the curve or deserialization error
+            // valid only if both crieterion is met
+            let tmp0 = circuit.issue_wire();
+            circuit.add_gate(crate::Gate {
+                wire_a: rhs_is_qr,
+                wire_b: flags_is_valid,
+                wire_c: tmp0,
+                gate_type: crate::GateType::And,
+            });
+            tmp0
+        };
 
         DecompressedG2Wires {
             point: G2Projective {
@@ -626,7 +684,7 @@ impl G2Projective {
                     Fq::new_constant(&zero_m).unwrap(),
                 ]),
             },
-            is_valid: rhs_is_qr,
+            is_valid: input_is_valid,
         }
     }
 }

--- a/g16ckt/src/gadgets/bn254/g2.rs
+++ b/g16ckt/src/gadgets/bn254/g2.rs
@@ -526,6 +526,37 @@ impl G2Projective {
         }
     }
 
+    /// check whether or not the point is on the curve or not
+    /// checks y^2=x^3+Bz^6 (Jacobian projective coordinates)
+    #[component]
+    pub fn is_on_curve<C: CircuitContext>(circuit: &mut C, p: &G2Projective) -> WireId {
+        let x2 = Fq2::square_montgomery(circuit, &p.x);
+        let x3 = Fq2::mul_montgomery(circuit, &p.x, &x2);
+        let y2 = Fq2::square_montgomery(circuit, &p.y);
+        let z2 = Fq2::square_montgomery(circuit, &p.z);
+        let z4 = Fq2::square_montgomery(circuit, &z2);
+        let z6 = Fq2::mul_montgomery(circuit, &z2, &z4);
+        let b_z6 = Fq2::mul_by_constant_montgomery(
+            circuit,
+            &z6,
+            &Fq2::as_montgomery(ark_bn254::g2::Config::COEFF_B),
+        );
+        let temp = Fq2::add(circuit, &x3, &b_z6);
+        let should_be_zero = Fq2::sub(circuit, &y2, &temp);
+        {
+            let c0 = bigint::equal_zero(circuit, should_be_zero.c0());
+            let c1 = bigint::equal_zero(circuit, should_be_zero.c1());
+            let is_zero = circuit.issue_wire();
+            circuit.add_gate(crate::Gate {
+                wire_a: c0,
+                wire_b: c1,
+                wire_c: is_zero,
+                gate_type: crate::GateType::And,
+            });
+            is_zero
+        }
+    }
+
     /// Deserialize into G2Projective from its 64 byte serialized bit representation.
     // Follows arkworks implementation here:
     // https://github.com/arkworks-rs/algebra/blob/v0.5.0/ec/src/models/short_weierstrass/mod.rs#L145
@@ -1201,5 +1232,38 @@ mod tests {
             assert_eq!(calc_is_valid, ref_is_valid);
             assert_eq!(calc_is_valid, pt.is_on_curve());
         }
+    }
+
+    #[test]
+    fn test_g2_is_on_curve() {
+        let mut rng = ChaCha20Rng::seed_from_u64(111);
+        let r = ark_bn254::G2Projective::rand(&mut rng);
+        let ref_is_on_curve = r.into_affine().is_on_curve();
+        let input = G2Input {
+            points: [G2Projective::as_montgomery(r)],
+        };
+        let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
+            CircuitBuilder::streaming_execute(input, 10_000, |ctx, wires| {
+                let is_on_curve = G2Projective::is_on_curve(ctx, &wires.points[0]);
+                vec![is_on_curve]
+            });
+        assert_eq!(out.output_value[0], ref_is_on_curve);
+
+        // not a point on curve
+        let r = ark_bn254::G2Projective::new_unchecked(
+            ark_bn254::Fq2::rand(&mut rng),
+            ark_bn254::Fq2::rand(&mut rng),
+            ark_bn254::Fq2::rand(&mut rng),
+        );
+        let input = G2Input {
+            points: [G2Projective::as_montgomery(r)],
+        };
+        let ref_is_on_curve = r.into_affine().is_on_curve();
+        let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
+            CircuitBuilder::streaming_execute(input, 10_000, |ctx, wires| {
+                let is_on_curve = G2Projective::is_on_curve(ctx, &wires.points[0]);
+                vec![is_on_curve]
+            });
+        assert_eq!(out.output_value[0], ref_is_on_curve);
     }
 }

--- a/g16ckt/src/gadgets/bn254/g2.rs
+++ b/g16ckt/src/gadgets/bn254/g2.rs
@@ -1,13 +1,14 @@
 use std::{cmp::min, collections::HashMap, iter::zip};
 
-use ark_ff::Zero;
+use ark_ec::short_weierstrass::SWCurveConfig;
+use ark_ff::{AdditiveGroup, Field, Zero};
 use circuit_component_macro::component;
 
 use crate::{
     CircuitContext, WireId,
     circuit::{FromWires, WiresArity, WiresObject},
     gadgets::{
-        bigint::Error,
+        bigint::{self, BigIntWires, Error},
         bn254::{fp254impl::Fp254Impl, fq::Fq, fq2::Fq2, fr::Fr},
     },
 };
@@ -524,6 +525,142 @@ impl G2Projective {
             z: p.z.clone(),
         }
     }
+
+    /// Deserialize into G1Projective from its 32 byte serialized bit representation.
+    pub fn deserialize_checked<C: CircuitContext>(
+        circuit: &mut C,
+        serialized_bits: [WireId; 64 * 8],
+    ) -> DecompressedG2Wires {
+        let (x, flag) = {
+            let byte_arr: Vec<[WireId; 8]> = serialized_bits
+                .chunks(8)
+                .map(|c| c.try_into().expect("chunk is exactly 8"))
+                .collect();
+            // flatten byte_array
+            let bit_arr: Vec<WireId> = byte_arr.into_iter().flatten().collect();
+            let (num1, num2, flag) = (
+                &bit_arr[0..Fq::N_BITS],
+                &bit_arr[32 * 8..32 * 8 + Fq::N_BITS],
+                &bit_arr[32 * 8 + Fq::N_BITS..],
+            );
+            let a = Fq2([
+                Fq(BigIntWires {
+                    bits: num1.to_vec(),
+                }),
+                Fq(BigIntWires {
+                    bits: num2.to_vec(),
+                }),
+            ]);
+
+            let r = Fq::as_montgomery(ark_bn254::Fq::ONE);
+            let a_mont_x = Fq::mul_by_constant_montgomery(circuit, a.c0(), &r.square());
+            let r = Fq::as_montgomery(ark_bn254::Fq::ONE);
+            let a_mont_y = Fq::mul_by_constant_montgomery(circuit, a.c1(), &r.square());
+
+            (Fq2([a_mont_x, a_mont_y]), flag.to_vec())
+        };
+
+        let y_neg_flag = circuit.issue_wire();
+        circuit.add_gate(crate::Gate {
+            wire_a: flag[0],
+            wire_b: flag[1],
+            wire_c: y_neg_flag,
+            gate_type: crate::GateType::Or,
+        });
+
+        let x2 = Fq2::square_montgomery(circuit, &x);
+
+        let x3 = Fq2::mul_montgomery(circuit, &x2, &x);
+
+        let y2 = Fq2::add_constant(
+            circuit,
+            &x3,
+            &Fq2::as_montgomery(ark_bn254::g2::Config::COEFF_B),
+        );
+
+        let y = Fq2::sqrt_general_montgomery(circuit, &y2);
+        let rhs_is_qr = {
+            // check if y * y == y2 to ensure rhs was a quadratic residue to begin with
+            let y_y = Fq2::square_montgomery(circuit, &y);
+
+            let match_c0 = bigint::equal(circuit, y2.c0(), y_y.c0());
+            let match_c1 = bigint::equal(circuit, y2.c1(), y_y.c1());
+            let match_c0_and_c1 = circuit.issue_wire();
+            circuit.add_gate(crate::Gate {
+                wire_a: match_c0,
+                wire_b: match_c1,
+                wire_c: match_c0_and_c1,
+                gate_type: crate::GateType::And,
+            });
+            match_c0_and_c1
+        };
+
+        let neg_y = Fq2::neg(circuit, y.clone());
+
+        let y_neg_greater = Fq2::greater_than(circuit, &neg_y, &y);
+        let tsy = {
+            let tsy_c0 = bigint::select(circuit, y.c0(), neg_y.c0(), y_neg_greater);
+            let tsy_c1 = bigint::select(circuit, y.c1(), neg_y.c1(), y_neg_greater);
+            Fq2([Fq(tsy_c0), Fq(tsy_c1)])
+        };
+        let tsy_neg = {
+            let tsy_neg_c0 = bigint::select(circuit, neg_y.c0(), y.c0(), y_neg_greater);
+            let tsy_neg_c1 = bigint::select(circuit, neg_y.c1(), y.c1(), y_neg_greater);
+            Fq2([Fq(tsy_neg_c0), Fq(tsy_neg_c1)])
+        };
+
+        let final_y_0 = bigint::select(circuit, tsy_neg.c0(), tsy.c0(), y_neg_flag);
+        let final_y_1 = bigint::select(circuit, tsy_neg.c1(), tsy.c1(), y_neg_flag);
+
+        // z = 1 in Montgomery
+        let one_m = Fq::as_montgomery(ark_bn254::Fq::ONE);
+        let zero_m = Fq::as_montgomery(ark_bn254::Fq::ZERO);
+
+        DecompressedG2Wires {
+            point: G2Projective {
+                x: x.clone(),
+                y: Fq2([Fq(final_y_0), Fq(final_y_1)]),
+                // In Fq2, ONE is (c0=1, c1=0). Use Montgomery representation.
+                z: Fq2([
+                    Fq::new_constant(&one_m).unwrap(),
+                    Fq::new_constant(&zero_m).unwrap(),
+                ]),
+            },
+            is_valid: rhs_is_qr,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CompressedG2Wires {
+    pub p: Fq2,
+    pub y_flag: WireId,
+}
+
+impl CompressedG2Wires {
+    pub fn new(mut issue: impl FnMut() -> WireId) -> Self {
+        Self {
+            p: Fq2::new(&mut issue),
+            y_flag: issue(),
+        }
+    }
+}
+
+impl WiresObject for CompressedG2Wires {
+    fn to_wires_vec(&self) -> Vec<WireId> {
+        let Self { p, y_flag } = self;
+
+        let mut v = p.to_wires_vec();
+        v.push(*y_flag);
+        v
+    }
+
+    fn clone_from(&self, wire_gen: &mut impl FnMut() -> WireId) -> Self {
+        Self {
+            p: self.p.clone_from(wire_gen),
+            y_flag: self.y_flag.clone_from(wire_gen),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -564,8 +701,9 @@ impl WiresArity for DecompressedG2Wires {
 
 #[cfg(test)]
 mod tests {
-    use ark_ec::{CurveGroup, VariableBaseMSM};
+    use ark_ec::{CurveGroup, PrimeGroup, VariableBaseMSM};
     use ark_ff::{Field, UniformRand};
+    use ark_serialize::CanonicalSerialize;
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha20Rng;
 
@@ -936,5 +1074,74 @@ mod tests {
 
         let actual_result = G2Projective::from_bits_unchecked(circuit_result.output_value.clone());
         assert_eq!(actual_result, G2Projective::as_montgomery(result));
+    }
+
+    #[test]
+    fn test_g2_compress_decompress_matches() {
+        let mut rng = ChaCha20Rng::seed_from_u64(222);
+        let r = ark_bn254::Fr::rand(&mut rng);
+        let p = (ark_bn254::G2Projective::generator() * r).into_affine();
+
+        let mut p_bytes = Vec::new();
+        p.serialize_compressed(&mut p_bytes).unwrap();
+        let input: Vec<bool> = p_bytes
+            .iter()
+            .flat_map(|&b| (0..8).map(move |i| ((b >> i) & 1) == 1))
+            .collect();
+        let input: [bool; 64 * 8] = input.try_into().unwrap();
+
+        let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
+            CircuitBuilder::streaming_execute(input, 20_000, |ctx, wires| {
+                let res = G2Projective::deserialize_checked(ctx, *wires);
+                let dec = res.point;
+
+                let exp = G2Projective::as_montgomery(p.into());
+                let x_ok = Fq2::equal_constant(ctx, &dec.x, &exp.x);
+                let z_ok = Fq2::equal_constant(ctx, &dec.z, &exp.z);
+                // Compare y up to sign by checking y^2 equality
+                let y_sq = Fq2::square_montgomery(ctx, &dec.y);
+                let exp_y_std = Fq2::from_montgomery(exp.y);
+                let exp_y_sq_m = Fq2::as_montgomery(exp_y_std.square());
+                let y_ok = Fq2::equal_constant(ctx, &y_sq, &exp_y_sq_m);
+                vec![x_ok, y_ok, z_ok, res.is_valid]
+            });
+
+        assert!(out.output_value.iter().all(|&b| b));
+    }
+
+    #[test]
+    fn test_g2_decompress_failure() {
+        let mut rng = ChaCha20Rng::seed_from_u64(112);
+        for _ in 0..5 {
+            // sufficient sample size to sample both valid and invalid points
+            let x = ark_bn254::Fq2::rand(&mut rng);
+            let a1 = ark_bn254::Fq2::sqrt(&((x * x * x) + ark_bn254::g2::Config::COEFF_B));
+            let (y, ref_is_valid) = if let Some(a1) = a1 {
+                // if it is possible to take square root, you have found correct y,
+                (a1, true)
+            } else {
+                // else generate some random value
+                (ark_bn254::Fq2::rand(&mut rng), false)
+            };
+            let pt = ark_bn254::G2Affine::new_unchecked(x, y);
+
+            let mut p_bytes = Vec::new();
+            pt.serialize_compressed(&mut p_bytes).unwrap();
+            let input: Vec<bool> = p_bytes
+                .iter()
+                .flat_map(|&b| (0..8).map(move |i| ((b >> i) & 1) == 1))
+                .collect();
+            let input: [bool; 64 * 8] = input.try_into().unwrap();
+
+            let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
+                CircuitBuilder::streaming_execute(input, 10_000, |ctx, wires| {
+                    let dec = G2Projective::deserialize_checked(ctx, *wires);
+                    vec![dec.is_valid]
+                });
+            let calc_is_valid = out.output_value[0];
+
+            assert_eq!(calc_is_valid, ref_is_valid);
+            assert_eq!(calc_is_valid, pt.is_on_curve());
+        }
     }
 }

--- a/g16ckt/src/gadgets/bn254/pairing.rs
+++ b/g16ckt/src/gadgets/bn254/pairing.rs
@@ -19,11 +19,14 @@ use ark_ff::{AdditiveGroup, Field};
 use circuit_component_macro::component;
 
 use crate::{
-    CircuitContext, Fp254Impl,
-    circuit::{FromWires, OffCircuitParam, WiresArity, WiresObject},
-    gadgets::bn254::{
-        final_exponentiation::final_exponentiation_montgomery, fq::Fq, fq2::Fq2, fq6::Fq6,
-        fq12::Fq12, g1::G1Projective, g2::G2Projective,
+    CircuitContext, Fp254Impl, WireId,
+    circuit::{FromWires, OffCircuitParam, TRUE_WIRE, WiresArity, WiresObject},
+    gadgets::{
+        bigint,
+        bn254::{
+            final_exponentiation::final_exponentiation_montgomery, fq::Fq, fq2::Fq2, fq6::Fq6,
+            fq12::Fq12, g1::G1Projective, g2::G2Projective,
+        },
     },
 };
 
@@ -504,7 +507,12 @@ pub fn mul_by_char_montgomery(circuit: &mut impl CircuitContext, r: &G2Projectiv
 /// the order used by arkworks' BN254 prepared coefficients (ell_0, ell_vw, ell_vv). The sequence
 /// contains one triple per doubling step and, conditionally, one per addition step depending on
 /// the signed bits of `ATE_LOOP_COUNT`, followed by two final frobenius-based additions.
-pub fn ell_coeffs_montgomery<C: CircuitContext>(circuit: &mut C, q: &G2Projective) -> Vec<Fq6> {
+///
+/// Returns a flag indicating whether the point 'q' is in subgroup
+pub fn ell_coeffs_montgomery<C: CircuitContext>(
+    circuit: &mut C,
+    q: &G2Projective,
+) -> (Vec<Fq6>, WireId) {
     let neg_q = g2_affine_neg_evaluate(circuit, q);
 
     let mut ellc: Vec<Fq6> = vec![];
@@ -531,6 +539,8 @@ pub fn ell_coeffs_montgomery<C: CircuitContext>(circuit: &mut C, q: &G2Projectiv
 
     let q1 = mul_by_char_montgomery(circuit, q);
     let mut q2 = mul_by_char_montgomery(circuit, &q1);
+    let q3 = mul_by_char_montgomery(circuit, &q2);
+
     let new_q2 = g2_affine_neg_evaluate(circuit, &q2);
     q2 = new_q2;
 
@@ -538,10 +548,30 @@ pub fn ell_coeffs_montgomery<C: CircuitContext>(circuit: &mut C, q: &G2Projectiv
     ellc.push(coeffs);
     r = new_r;
 
-    let (_new_r, coeffs) = add_in_place_montgomery(circuit, &r, &q2);
+    let (new_r, coeffs) = add_in_place_montgomery(circuit, &r, &q2);
     ellc.push(coeffs);
+    r = new_r;
 
-    ellc
+    let (new_r, _) = add_in_place_montgomery(circuit, &r, &q3);
+
+    // https://github.com/BitVM/BitVM/issues/191#issuecomment-2596825624
+    let is_in_sg = {
+        let z0 = new_r.z.c0();
+
+        let z1 = new_r.z.c1();
+        let z0_is_zero = bigint::equal_zero(circuit, z0);
+        let z1_is_zero = bigint::equal_zero(circuit, z1);
+        let z_is_zero = circuit.issue_wire();
+        circuit.add_gate(crate::Gate {
+            wire_a: z0_is_zero,
+            wire_b: z1_is_zero,
+            wire_c: z_is_zero,
+            gate_type: crate::GateType::And,
+        });
+        z0_is_zero
+    };
+
+    (ellc, is_in_sg)
 }
 
 /// Miller loop where P is already affine (z = 1), so no normalization needed.
@@ -641,7 +671,7 @@ pub fn multi_miller_loop_montgomery_fast<C: CircuitContext>(
     circuit: &mut C,
     ps: &[G1Projective],
     qs: &[G2Projective],
-) -> Fq12 {
+) -> ValidFq12 {
     // Skip normalization - assume inputs are already affine (z = 1)
     // - ell_coeffs_montgomery assumes mixed-add with affine Q (z = 1)
     // - ell_montgomery evaluates at affine P (z = 1)
@@ -649,9 +679,20 @@ pub fn multi_miller_loop_montgomery_fast<C: CircuitContext>(
     let qs_aff = qs.to_vec();
 
     let mut qells = Vec::new();
+    let mut valid_sg = TRUE_WIRE;
+
     for q in &qs_aff {
         let qell = ell_coeffs_montgomery(circuit, q);
-        qells.push(qell);
+        qells.push(qell.0);
+
+        let tmp0 = circuit.issue_wire();
+        circuit.add_gate(crate::Gate {
+            wire_a: valid_sg,
+            wire_b: qell.1,
+            wire_c: tmp0,
+            gate_type: crate::GateType::And,
+        });
+        valid_sg = tmp0;
     }
     let mut u = Vec::new();
     for i in 0..qells[0].len() {
@@ -694,7 +735,62 @@ pub fn multi_miller_loop_montgomery_fast<C: CircuitContext>(
         f = ell_montgomery(circuit, &f, &qell_next, p);
     }
 
-    f
+    ValidFq12 {
+        f,
+        is_valid: valid_sg,
+    }
+}
+
+/// Analogous to Option<Fq12> where `is_valid` carries `false` if variable is None
+#[derive(Clone, Debug)]
+pub struct ValidFq12 {
+    pub f: Fq12,
+    pub is_valid: WireId,
+}
+
+impl WiresObject for ValidFq12 {
+    fn to_wires_vec(&self) -> Vec<WireId> {
+        let mut wires: Vec<WireId> = self.f.0[0]
+            .to_wires_vec()
+            .into_iter()
+            .chain(self.f.0[1].to_wires_vec())
+            .collect();
+        wires.push(self.is_valid);
+        wires
+    }
+
+    fn clone_from(&self, mut wire_gen: &mut impl FnMut() -> WireId) -> Self {
+        ValidFq12 {
+            f: Fq12([
+                self.f.0[0].clone_from(&mut wire_gen),
+                self.f.0[1].clone_from(&mut wire_gen),
+            ]),
+            is_valid: wire_gen(),
+        }
+    }
+}
+
+impl FromWires for ValidFq12 {
+    fn from_wires(wires: &[WireId]) -> Option<Self> {
+        if wires.len() == ValidFq12::ARITY {
+            let mid = Fq6::N_BITS;
+            let fq6_1 = Fq6::from_wires(&wires[..mid])?;
+            let fq6_2 = Fq6::from_wires(&wires[mid..2 * mid])?;
+            let is_valid_wires = &wires[2 * mid..];
+            assert_eq!(is_valid_wires.len(), 1); // single is valid wire
+            let res = ValidFq12 {
+                f: Fq12([fq6_1, fq6_2]),
+                is_valid: is_valid_wires[0],
+            };
+            Some(res)
+        } else {
+            None
+        }
+    }
+}
+
+impl WiresArity for ValidFq12 {
+    const ARITY: usize = Fq12::N_BITS + 1;
 }
 
 fn new_fq12_constant_montgomery(v: ark_bn254::Fq12) -> Fq12 {
@@ -846,8 +942,8 @@ pub fn miller_loop_montgomery_fast<C: CircuitContext>(
     circuit: &mut C,
     p: &G1Projective,
     q: &G2Projective,
-) -> Fq12 {
-    let qell = ell_coeffs_montgomery(circuit, q);
+) -> ValidFq12 {
+    let (qell, is_valid_sg) = ell_coeffs_montgomery(circuit, q);
     let mut q_ell = qell.iter();
 
     let mut f = new_fq12_constant_montgomery(ark_bn254::Fq12::ONE);
@@ -872,7 +968,11 @@ pub fn miller_loop_montgomery_fast<C: CircuitContext>(
     f = ell_montgomery(circuit, &f, &qell_next, p);
     let qell_next = q_ell.next().unwrap().clone();
 
-    ell_montgomery(circuit, &f, &qell_next, p)
+    let res = ell_montgomery(circuit, &f, &qell_next, p);
+    ValidFq12 {
+        f: res,
+        is_valid: is_valid_sg,
+    }
 }
 
 // Final exponentiation logic has moved to gadgets::bn254::final_exponentiation
@@ -950,10 +1050,10 @@ pub fn multi_miller_loop_groth16_evaluate_montgomery_fast<C: CircuitContext>(
     q1: ark_bn254::G2Affine,
     q2: ark_bn254::G2Affine,
     q3: &G2Projective,
-) -> Fq12 {
+) -> ValidFq12 {
     let q1ell = ell_coeffs(q1);
     let q2ell = ell_coeffs(q2);
-    let q3ell = ell_coeffs_montgomery(circuit, q3);
+    let (q3ell, is_in_valid_sg) = ell_coeffs_montgomery(circuit, q3);
     let mut q1_ell = q1ell.iter();
     let mut q2_ell = q2ell.iter();
     let mut q3_ell = q3ell.iter();
@@ -1005,7 +1105,10 @@ pub fn multi_miller_loop_groth16_evaluate_montgomery_fast<C: CircuitContext>(
     let q3ell_next = q3_ell.next().unwrap().clone();
     f = ell_montgomery(circuit, &f, &q3ell_next, p3);
 
-    f
+    ValidFq12 {
+        f,
+        is_valid: is_in_valid_sg,
+    }
 }
 
 #[cfg(test)]
@@ -1035,6 +1138,28 @@ mod tests {
 
     fn random_g2_affine(rng: &mut impl Rng) -> ark_bn254::G2Affine {
         (ark_bn254::G2Projective::generator() * rnd_fr(rng)).into_affine()
+    }
+
+    // get valid point in curve that is not in subgroup
+    fn random_g2_affine_sg(rng: &mut impl Rng) -> ark_bn254::G2Affine {
+        let mut pt = ark_bn254::G2Affine::identity();
+        for _ in 0..5 {
+            // sufficient sample size to sample both valid and invalid points
+            let x = ark_bn254::Fq2::rand(rng);
+            let a1 = ark_bn254::Fq2::sqrt(&((x * x * x) + ark_bn254::g2::Config::COEFF_B));
+            let (y, ref_is_valid) = if let Some(a1) = a1 {
+                // if it is possible to take square root, you have found correct y,
+                (a1, true)
+            } else {
+                // else generate some random value
+                (ark_bn254::Fq2::rand(rng), false)
+            };
+            if ref_is_valid {
+                pt = ark_bn254::G2Affine::new_unchecked(x, y);
+                break;
+            }
+        }
+        pt
     }
 
     #[test]
@@ -1146,9 +1271,14 @@ mod tests {
         };
         let result =
             CircuitBuilder::streaming_execute::<_, _, Fq12Output>(input, 10_000, |ctx, w| {
-                ell_montgomery(ctx, &w.f, &w.c, &w.p)
+                let res = ell_montgomery(ctx, &w.f, &w.c, &w.p);
+                ValidFq12 {
+                    f: res,
+                    is_valid: TRUE_WIRE,
+                }
             });
 
+        assert!(result.output_value.is_valid, "should be valid subgroup");
         assert_eq!(result.output_value.value, expected_m);
     }
 
@@ -1577,7 +1707,7 @@ mod tests {
                 let got = ell_coeffs_montgomery(ctx, &wires.q);
                 // Combine all equality checks into one flag
                 let mut ok = TRUE_WIRE;
-                for (i, coeff) in got.into_iter().enumerate() {
+                for (i, coeff) in got.0.into_iter().enumerate() {
                     let c0 = coeff.0[0].clone();
                     let c1 = coeff.0[1].clone();
                     let c2 = coeff.0[2].clone();
@@ -1598,11 +1728,42 @@ mod tests {
                     ctx.add_gate(Gate::and(ok, t, new_ok));
                     ok = new_ok;
                 }
-                vec![ok]
+                let valid = ctx.issue_wire();
+                ctx.add_gate(Gate {
+                    wire_a: ok,
+                    wire_b: got.1,
+                    wire_c: valid,
+                    gate_type: crate::GateType::And,
+                });
+                vec![valid]
             },
         );
 
         assert!(out.output_value[0]);
+
+        for _ in 0..3 {
+            // iterating in case we sample a point that exactly lies on a subgroup on some try
+            let r = random_g2_affine_sg(&mut rng);
+            assert!(
+                r.is_on_curve(),
+                "random_g2_affine_sg should give a point on curve"
+            );
+            let out = CircuitBuilder::streaming_execute::<_, _, Vec<bool>>(
+                In {
+                    q: ark_bn254::G2Projective::new_unchecked(r.x, r.y, ark_bn254::Fq2::ONE),
+                },
+                50_000,
+                |ctx, wires| {
+                    let got = ell_coeffs_montgomery(ctx, &wires.q);
+                    vec![got.1]
+                },
+            );
+            // match validity of subgroup returned by circuit with that from input reference point
+            assert_eq!(
+                out.output_value[0],
+                r.is_in_correct_subgroup_assuming_on_curve()
+            );
+        }
     }
 
     #[test]
@@ -1882,11 +2043,16 @@ mod tests {
             10_000,
             |ctx, input| {
                 let f_ml = miller_loop_montgomery_fast(ctx, &input.p, &input.q);
-                final_exponentiation_montgomery(ctx, &f_ml)
+                let fexp = final_exponentiation_montgomery(ctx, &f_ml.f);
+                ValidFq12 {
+                    f: fexp,
+                    is_valid: f_ml.is_valid,
+                }
             },
         );
 
         assert_eq!(result.output_value.value, expected_m);
+        assert!(result.output_value.is_valid, "G2 point must be in subgroup");
     }
     // Local decoder helpers for Fq12 output
     fn decode_fq6_from_wires(
@@ -1914,14 +2080,19 @@ mod tests {
 
     struct Fq12Output {
         value: ark_bn254::Fq12,
+        is_valid: bool,
     }
     impl CircuitOutput<ExecuteMode> for Fq12Output {
-        type WireRepr = Fq12;
+        type WireRepr = ValidFq12;
         fn decode(wires: Self::WireRepr, cache: &mut ExecuteMode) -> Self {
-            let c0 = decode_fq6_from_wires(&wires.0[0], cache);
-            let c1 = decode_fq6_from_wires(&wires.0[1], cache);
+            let c0 = decode_fq6_from_wires(&wires.f.0[0], cache);
+            let c1 = decode_fq6_from_wires(&wires.f.0[1], cache);
+            let is_valid = cache
+                .lookup_wire(wires.is_valid)
+                .expect("missing wire value");
             Self {
                 value: ark_bn254::Fq12::new(c0, c1),
+                is_valid,
             }
         }
     }
@@ -2018,7 +2189,11 @@ mod tests {
         };
         let result =
             CircuitBuilder::streaming_execute::<_, _, Fq12Output>(input, 10_000, |ctx, input| {
-                ell_eval_const(ctx, &input.f, &coeff, &input.p)
+                let f = ell_eval_const(ctx, &input.f, &coeff, &input.p);
+                ValidFq12 {
+                    f,
+                    is_valid: TRUE_WIRE,
+                }
             });
 
         assert_eq!(result.output_value.value, expected_m);
@@ -2095,7 +2270,13 @@ mod tests {
         let result = CircuitBuilder::streaming_execute::<_, _, Fq12Output>(
             In { p },
             10_000,
-            |ctx, input| miller_loop_const_q(ctx, &input.p, &q),
+            |ctx, input| {
+                let f = miller_loop_const_q(ctx, &input.p, &q);
+                ValidFq12 {
+                    f,
+                    is_valid: TRUE_WIRE,
+                }
+            },
         );
 
         assert_eq!(result.output_value.value, expected_m);
@@ -2172,7 +2353,13 @@ mod tests {
         let result = CircuitBuilder::streaming_execute::<_, _, Fq12Output>(
             In { p },
             10_000,
-            |ctx, input| pairing_const_q(ctx, &input.p, &q),
+            |ctx, input| {
+                let f = pairing_const_q(ctx, &input.p, &q);
+                ValidFq12 {
+                    f,
+                    is_valid: TRUE_WIRE,
+                }
+            },
         );
 
         assert_eq!(result.output_value.value, expected_m);
@@ -2263,7 +2450,11 @@ mod tests {
             10_000,
             |ctx, input| {
                 let ps = [input.p0.clone(), input.p1.clone(), input.p2.clone()];
-                multi_pairing_const_q(ctx, &ps, &[q0, q1, q2])
+                let res = multi_pairing_const_q(ctx, &ps, &[q0, q1, q2]);
+                ValidFq12 {
+                    f: res,
+                    is_valid: TRUE_WIRE,
+                }
             },
         );
 
@@ -2682,11 +2873,9 @@ mod tests {
         // Exercise several randomized and edge cases
         let mut rng = ChaCha20Rng::seed_from_u64(0xC011EC7);
         for case in 0..4u32 {
-            // Select points per case
             let (p1, p2, p3, q1, q2, q3) = match case {
-                // Fully random points
-                0..=3 => {
-                    // Normalize Ps to affine (z=1) before encoding, matching gadget expectations
+                // q3 may be in subgroup G2
+                0..=2 => {
                     let p1 = (ark_bn254::G1Projective::generator() * rnd_fr(&mut rng))
                         .into_affine()
                         .into_group();
@@ -2698,12 +2887,15 @@ mod tests {
                         .into_group();
                     let q1 = random_g2_affine(&mut rng);
                     let q2 = random_g2_affine(&mut rng);
-                    // Ensure q3 is affine (z = 1) for mixed-add formulas
-                    let q3_aff = random_g2_affine(&mut rng);
-                    let q3 = ark_bn254::G2Projective::new(q3_aff.x, q3_aff.y, ark_bn254::Fq2::ONE);
+                    let q3_aff = random_g2_affine_sg(&mut rng);
+                    let q3 = ark_bn254::G2Projective::new_unchecked(
+                        q3_aff.x,
+                        q3_aff.y,
+                        ark_bn254::Fq2::ONE,
+                    );
                     (p1, p2, p3, q1, q2, q3)
                 }
-                // q3 with z = 1 (affine form encoded as projective) to exercise mixed-add friendly path
+                // q3 is chosen to be from subgroup G2
                 _ => {
                     let p1 = (ark_bn254::G1Projective::generator() * rnd_fr(&mut rng))
                         .into_affine()
@@ -2735,6 +2927,10 @@ mod tests {
                     )
                 });
 
+            assert_eq!(
+                q3.into_affine().is_in_correct_subgroup_assuming_on_curve(),
+                result.output_value.is_valid
+            );
             assert_eq!(
                 result.output_value.value, expected_m,
                 "case {case} mismatch"

--- a/g16ckt/src/gadgets/bn254/pairing.rs
+++ b/g16ckt/src/gadgets/bn254/pairing.rs
@@ -575,7 +575,7 @@ pub fn ell_coeffs_montgomery<C: CircuitContext>(
             wire_c: z_is_zero,
             gate_type: crate::GateType::And,
         });
-        z0_is_zero
+        z_is_zero
     };
 
     (ellc, is_in_sg)

--- a/g16ckt/src/gadgets/bn254/pairing.rs
+++ b/g16ckt/src/gadgets/bn254/pairing.rs
@@ -554,7 +554,9 @@ pub fn ell_coeffs_montgomery<C: CircuitContext>(
 
     let (new_r, _) = add_in_place_montgomery(circuit, &r, &q3);
 
-    // https://github.com/BitVM/BitVM/issues/191#issuecomment-2596825624
+    // Cheap subgroup check approach:
+    // https://eprint.iacr.org/2022/348.pdf Section 3.1.2 Remark 2
+    // `ark_bn254::Config::ATE_LOOP_COUNT` is `6z + 2` mentioned in the remark.
     let is_in_sg = {
         let z0 = new_r.z.c0();
 

--- a/g16ckt/src/gadgets/groth16.rs
+++ b/g16ckt/src/gadgets/groth16.rs
@@ -16,8 +16,13 @@ use crate::{
     gadgets::{
         bigint,
         bn254::{
-            G2Projective, final_exponentiation::final_exponentiation_montgomery, fq::Fq,
-            fq12::Fq12, fr::Fr, g1::G1Projective,
+            G2Projective,
+            final_exponentiation::final_exponentiation_montgomery,
+            fq::Fq,
+            fq12::Fq12,
+            fr::Fr,
+            g1::{DecompressedG1Wires, G1Projective},
+            g2::DecompressedG2Wires,
             pairing::multi_miller_loop_groth16_evaluate_montgomery_fast,
         },
     },
@@ -116,7 +121,7 @@ pub fn groth16_verify<C: CircuitContext>(
 pub fn decompress_g1_from_compressed<C: CircuitContext>(
     circuit: &mut C,
     compressed: &CompressedG1Wires,
-) -> G1Projective {
+) -> DecompressedG1Wires {
     let CompressedG1Wires { x_m, y_flag } = compressed.clone();
 
     // rhs = x^3 + b (Montgomery domain)
@@ -127,6 +132,10 @@ pub fn decompress_g1_from_compressed<C: CircuitContext>(
 
     // sy = sqrt(rhs) in Montgomery domain
     let sy = Fq::sqrt_montgomery(circuit, &rhs);
+    // check if sy * sy == rhs to ensure rhs was a quadratic residue to begin with
+    let sy_sy = Fq::square_montgomery(circuit, &sy);
+    let rhs_is_qr = bigint::equal(circuit, &sy_sy, &rhs);
+
     let sy_neg = Fq::neg(circuit, &sy);
     let y_bits = bigint::select(circuit, &sy.0, &sy_neg.0, y_flag);
     let y = Fq(y_bits);
@@ -135,10 +144,13 @@ pub fn decompress_g1_from_compressed<C: CircuitContext>(
     let one_m = Fq::as_montgomery(ark_bn254::Fq::ONE);
     let z = Fq::new_constant(&one_m).expect("const one mont");
 
-    G1Projective {
-        x: x_m.clone(),
-        y,
-        z,
+    DecompressedG1Wires {
+        point: G1Projective {
+            x: x_m.clone(),
+            y,
+            z,
+        },
+        is_valid: rhs_is_qr,
     }
 }
 
@@ -146,7 +158,7 @@ pub fn decompress_g1_from_compressed<C: CircuitContext>(
 pub fn decompress_g2_from_compressed<C: CircuitContext>(
     circuit: &mut C,
     compressed: &CompressedG2Wires,
-) -> G2Projective {
+) -> DecompressedG2Wires {
     let CompressedG2Wires { p: x, y_flag } = compressed;
 
     let x2 = Fq2Wire::square_montgomery(circuit, x);
@@ -160,6 +172,21 @@ pub fn decompress_g2_from_compressed<C: CircuitContext>(
     );
 
     let y = Fq2Wire::sqrt_general_montgomery(circuit, &y2);
+    let rhs_is_qr = {
+        // check if y * y == y2 to ensure rhs was a quadratic residue to begin with
+        let y_y = Fq2Wire::square_montgomery(circuit, &y);
+
+        let match_c0 = bigint::equal(circuit, y2.c0(), y_y.c0());
+        let match_c1 = bigint::equal(circuit, y2.c1(), y_y.c1());
+        let match_c0_and_c1 = circuit.issue_wire();
+        circuit.add_gate(crate::Gate {
+            wire_a: match_c0,
+            wire_b: match_c1,
+            wire_c: match_c0_and_c1,
+            gate_type: crate::GateType::And,
+        });
+        match_c0_and_c1
+    };
 
     let neg_y = Fq2Wire::neg(circuit, y.clone());
 
@@ -168,16 +195,18 @@ pub fn decompress_g2_from_compressed<C: CircuitContext>(
 
     // z = 1 in Montgomery
     let one_m = Fq::as_montgomery(ark_bn254::Fq::ONE);
+    let one_m = Fq::new_constant(&one_m).expect("const one mont");
     let zero_m = Fq::as_montgomery(ark_bn254::Fq::ZERO);
+    let zero_m = Fq::new_constant(&zero_m).expect("const zero mont");
 
-    G2Projective {
-        x: x.clone(),
-        y: Fq2Wire([Fq(final_y_0), Fq(final_y_1)]),
-        // In Fq2, ONE is (c0=1, c1=0). Use Montgomery representation.
-        z: Fq2Wire([
-            Fq::new_constant(&one_m).unwrap(),
-            Fq::new_constant(&zero_m).unwrap(),
-        ]),
+    DecompressedG2Wires {
+        point: G2Projective {
+            x: x.clone(),
+            y: Fq2Wire([Fq(final_y_0), Fq(final_y_1)]),
+            // In Fq2, ONE is (c0=1, c1=0). Use Montgomery representation.
+            z: Fq2Wire([one_m, zero_m]),
+        },
+        is_valid: rhs_is_qr,
     }
 }
 
@@ -255,16 +284,44 @@ pub fn groth16_verify_compressed<C: CircuitContext>(
     let b = decompress_g2_from_compressed(circuit, &input.b);
     let c = decompress_g1_from_compressed(circuit, &input.c);
 
-    groth16_verify(
+    let valid_decompressed = {
+        let tmp0 = circuit.issue_wire();
+        let tmp1 = circuit.issue_wire();
+
+        circuit.add_gate(crate::Gate {
+            wire_a: a.is_valid,
+            wire_b: b.is_valid,
+            wire_c: tmp0,
+            gate_type: crate::GateType::And,
+        });
+        circuit.add_gate(crate::Gate {
+            wire_a: tmp0,
+            wire_b: c.is_valid,
+            wire_c: tmp1,
+            gate_type: crate::GateType::And,
+        });
+        tmp1
+    };
+
+    let verified_res = groth16_verify(
         circuit,
         &Groth16VerifyInputWires {
             public: input.public.clone(),
-            a,
-            b,
-            c,
+            a: a.point,
+            b: b.point,
+            c: c.point,
             vk: input.vk.clone(),
         },
-    )
+    );
+
+    let valid = circuit.issue_wire();
+    circuit.add_gate(crate::Gate {
+        wire_a: verified_res,
+        wire_b: valid_decompressed,
+        wire_c: valid,
+        gate_type: crate::GateType::And,
+    });
+    valid
 }
 
 #[derive(Debug, Clone)]
@@ -499,7 +556,7 @@ mod tests {
         r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError},
     };
     use ark_snark::{CircuitSpecificSetupSNARK, SNARK};
-    use rand::SeedableRng;
+    use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha20Rng;
     use test_log::test;
 
@@ -887,7 +944,8 @@ mod tests {
 
         let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
             CircuitBuilder::streaming_execute(input, 10_000, |ctx, wires| {
-                let dec = decompress_g1_from_compressed(ctx, wires);
+                let res = decompress_g1_from_compressed(ctx, wires);
+                let dec = res.point;
 
                 let exp = G1Projective::as_montgomery(p.into_group());
                 let x_ok = Fq::equal_constant(ctx, &dec.x, &exp.x);
@@ -897,10 +955,39 @@ mod tests {
                 let exp_y_std = Fq::from_montgomery(exp.y);
                 let exp_y_sq_m = Fq::as_montgomery(exp_y_std.square());
                 let y_ok = Fq::equal_constant(ctx, &y_sq, &exp_y_sq_m);
-                vec![x_ok, y_ok, z_ok]
+                vec![x_ok, y_ok, z_ok, res.is_valid]
             });
 
         assert!(out.output_value.iter().all(|&b| b));
+    }
+
+    #[test]
+    fn test_g1_decompress_failure() {
+        let mut rng = ChaCha20Rng::seed_from_u64(112);
+        for _ in 0..5 {
+            // sufficient sample size to sample both valid and invalid points
+            let x = ark_bn254::Fq::rand(&mut rng);
+            let a1 = ark_bn254::Fq::sqrt(&((x * x * x) + ark_bn254::Fq::from(3)));
+            let (y, ref_is_valid) = if let Some(a1) = a1 {
+                // if it is possible to take square root, you have found correct y,
+                (a1, true)
+            } else {
+                // else generate some random value
+                (ark_bn254::Fq::rand(&mut rng), false)
+            };
+            let pt = ark_bn254::G1Affine::new_unchecked(x, y);
+
+            let input = OnlyCompressedG1Input(pt);
+            let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
+                CircuitBuilder::streaming_execute(input, 10_000, |ctx, wires| {
+                    let dec = decompress_g1_from_compressed(ctx, wires);
+                    vec![dec.is_valid]
+                });
+            let calc_is_valid = out.output_value[0];
+
+            assert_eq!(calc_is_valid, ref_is_valid);
+            assert_eq!(calc_is_valid, pt.is_on_curve());
+        }
     }
 
     #[test]
@@ -913,7 +1000,8 @@ mod tests {
 
         let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
             CircuitBuilder::streaming_execute(input, 20_000, |ctx, wires| {
-                let dec = decompress_g2_from_compressed(ctx, wires);
+                let res = decompress_g2_from_compressed(ctx, wires);
+                let dec = res.point;
 
                 let exp = G2Projective::as_montgomery(p.into_group());
                 let x_ok = Fq2Wire::equal_constant(ctx, &dec.x, &exp.x);
@@ -923,10 +1011,72 @@ mod tests {
                 let exp_y_std = Fq2Wire::from_montgomery(exp.y);
                 let exp_y_sq_m = Fq2Wire::as_montgomery(exp_y_std.square());
                 let y_ok = Fq2Wire::equal_constant(ctx, &y_sq, &exp_y_sq_m);
-                vec![x_ok, y_ok, z_ok]
+                vec![x_ok, y_ok, z_ok, res.is_valid]
             });
 
         assert!(out.output_value.iter().all(|&b| b));
+    }
+
+    #[test]
+    fn test_g2_decompress_failure() {
+        let mut rng = ChaCha20Rng::seed_from_u64(112);
+        for _ in 0..5 {
+            // sufficient sample size to sample both valid and invalid points
+            let x = ark_bn254::Fq2::rand(&mut rng);
+            let a1 = ark_bn254::Fq2::sqrt(&((x * x * x) + ark_bn254::g2::Config::COEFF_B));
+            let (y, ref_is_valid) = if let Some(a1) = a1 {
+                // if it is possible to take square root, you have found correct y,
+                (a1, true)
+            } else {
+                // else generate some random value
+                (ark_bn254::Fq2::rand(&mut rng), false)
+            };
+            let pt = ark_bn254::G2Affine::new_unchecked(x, y);
+
+            let input = OnlyCompressedG2Input(pt);
+            let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
+                CircuitBuilder::streaming_execute(input, 10_000, |ctx, wires| {
+                    let dec = decompress_g2_from_compressed(ctx, wires);
+                    vec![dec.is_valid]
+                });
+            let calc_is_valid = out.output_value[0];
+
+            assert_eq!(calc_is_valid, ref_is_valid);
+            assert_eq!(calc_is_valid, pt.is_on_curve());
+        }
+    }
+
+    #[test]
+    fn test_cofactor_clearing() {
+        let mut rng = ChaCha20Rng::seed_from_u64(112);
+        for _ in 0..5 {
+            // sufficient sample size to sample both valid and invalid points
+            let x = ark_bn254::Fq2::rand(&mut rng);
+            let a1 = ark_bn254::Fq2::sqrt(&((x * x * x) + ark_bn254::g2::Config::COEFF_B));
+            let (y, ref_is_valid) = if let Some(a1) = a1 {
+                // if it is possible to take square root, you have found correct y,
+                (a1, true)
+            } else {
+                // else generate some random value
+                (ark_bn254::Fq2::rand(&mut rng), false)
+            };
+            let pt = ark_bn254::G2Affine::new_unchecked(x, y);
+
+            let pt = pt.into_group();
+            const COFACTOR: &[u64] = &[
+                0x345f2299c0f9fa8d,
+                0x06ceecda572a2489,
+                0xb85045b68181585e,
+                0x30644e72e131a029,
+            ];
+            let pt = pt.mul_bigint(COFACTOR);
+            let pt = pt.into_affine();
+            // if it's a valid point, it should be on curve and subgroup (after cofactor clearing)
+            assert_eq!(
+                ref_is_valid,
+                pt.is_on_curve() && pt.is_in_correct_subgroup_assuming_on_curve()
+            );
+        }
     }
 
     #[test]
@@ -952,9 +1102,13 @@ mod tests {
 
         let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
             CircuitBuilder::streaming_execute(inputs, 80_000, |ctx, wires| {
-                let a_dec = decompress_g1_from_compressed(ctx, &wires.a);
-                let b_dec = decompress_g2_from_compressed(ctx, &wires.b);
-                let c_dec = decompress_g1_from_compressed(ctx, &wires.c);
+                let a = decompress_g1_from_compressed(ctx, &wires.a);
+                let b = decompress_g2_from_compressed(ctx, &wires.b);
+                let c = decompress_g1_from_compressed(ctx, &wires.c);
+
+                let a_dec = a.point;
+                let b_dec = b.point;
+                let c_dec = c.point;
 
                 let a_exp = G1Projective::as_montgomery(proof.a.into_group());
                 let b_exp = G2Projective::as_montgomery(proof.b.into_group());
@@ -974,10 +1128,79 @@ mod tests {
 
                 vec![
                     a_x_ok, a_y_ok, a_z_ok, b_x_ok, b_y_ok, b_z_ok, c_x_ok, c_y_ok, c_z_ok,
+                    a.is_valid, b.is_valid, c.is_valid,
                 ]
             });
 
         assert!(out.output_value.iter().all(|&b| b));
+    }
+
+    #[test]
+    fn test_invalid_groth16_verify_compressed_true_small() {
+        // get valid point in curve that is not in subgroup
+        fn random_g2_affine_sg(rng: &mut impl Rng) -> ark_bn254::G2Affine {
+            let mut pt = ark_bn254::G2Affine::identity();
+            for _ in 0..5 {
+                // sufficient sample size to sample both valid and invalid points
+                let x = ark_bn254::Fq2::rand(rng);
+                let a1 = ark_bn254::Fq2::sqrt(&((x * x * x) + ark_bn254::g2::Config::COEFF_B));
+                let (y, ref_is_valid) = if let Some(a1) = a1 {
+                    // if it is possible to take square root, you have found correct y,
+                    (a1, true)
+                } else {
+                    // else generate some random value
+                    (ark_bn254::Fq2::rand(rng), false)
+                };
+                if ref_is_valid {
+                    pt = ark_bn254::G2Affine::new_unchecked(x, y);
+                    break;
+                }
+            }
+            pt
+        }
+
+        let k = 4; // circuit size; pairing cost dominates anyway
+        let mut rng = ChaCha20Rng::seed_from_u64(33333);
+        let circuit = DummyCircuit::<ark_bn254::Fr> {
+            a: Some(ark_bn254::Fr::rand(&mut rng)),
+            b: Some(ark_bn254::Fr::rand(&mut rng)),
+            num_variables: 8,
+            num_constraints: 1 << k,
+        };
+        let (pk, vk) = Groth16::<ark_bn254::Bn254>::setup(circuit, &mut rng).unwrap();
+        let c_val = circuit.a.unwrap() * circuit.b.unwrap();
+        let proof = Groth16::<ark_bn254::Bn254>::prove(&pk, circuit, &mut rng).unwrap();
+
+        // Case 1: Check that the proof is correct to begin with
+        let inputs = Groth16VerifyInput {
+            public: vec![c_val],
+            a: proof.a.into_group(),
+            b: proof.b.into_group(),
+            c: proof.c.into_group(),
+            vk: vk.clone(),
+        }
+        .compress();
+
+        let out: crate::circuit::StreamingResult<_, _, bool> =
+            CircuitBuilder::streaming_execute(inputs, 160_000, groth16_verify_compressed);
+
+        assert!(out.output_value, "should pass");
+
+        // Case 2: Check for invalid proof
+        let inputs = Groth16VerifyInput {
+            public: vec![c_val],
+
+            a: proof.a.into_group(),
+            b: random_g2_affine_sg(&mut rng).into_group(), // proof.b.into_group()
+            c: proof.c.into_group(),
+            vk,
+        }
+        .compress();
+
+        let out: crate::circuit::StreamingResult<_, _, bool> =
+            CircuitBuilder::streaming_execute(inputs, 160_000, groth16_verify_compressed);
+
+        assert!(!out.output_value, "should fail because invalid G2");
     }
 
     // Full end-to-end compressed Groth16 verification. This is heavy because it

--- a/g16ckt/src/gadgets/groth16.rs
+++ b/g16ckt/src/gadgets/groth16.rs
@@ -68,6 +68,28 @@ pub fn groth16_verify<C: CircuitContext>(
         vk,
     } = input;
 
+    let proof_is_on_curve = {
+        let a_is_on_curve = G1Projective::is_on_curve(circuit, a);
+        let b_is_on_curve = G2Projective::is_on_curve(circuit, b);
+        let c_is_on_curve = G1Projective::is_on_curve(circuit, c);
+
+        let tmp0 = circuit.issue_wire();
+        let tmp1 = circuit.issue_wire();
+        circuit.add_gate(crate::Gate {
+            wire_a: a_is_on_curve,
+            wire_b: b_is_on_curve,
+            wire_c: tmp0,
+            gate_type: crate::GateType::And,
+        });
+        circuit.add_gate(crate::Gate {
+            wire_a: tmp0,
+            wire_b: c_is_on_curve,
+            wire_c: tmp1,
+            gate_type: crate::GateType::And,
+        });
+        tmp1
+    };
+
     // Standard verification with public inputs
     // MSM: sum_i public[i] * gamma_abc_g1[i+1]
     let bases: Vec<ark_bn254::G1Projective> = vk
@@ -108,7 +130,16 @@ pub fn groth16_verify<C: CircuitContext>(
 
     let f = final_exponentiation_montgomery(circuit, &f);
 
-    Fq12::equal_constant(circuit, &f, &Fq12::as_montgomery(alpha_beta))
+    let finexp_match = Fq12::equal_constant(circuit, &f, &Fq12::as_montgomery(alpha_beta));
+
+    let valid = circuit.issue_wire();
+    circuit.add_gate(crate::Gate {
+        wire_a: finexp_match,
+        wire_b: proof_is_on_curve,
+        wire_c: valid,
+        gate_type: crate::GateType::And,
+    });
+    valid
 }
 
 /// Verify a 128-byte compressed serialized groth16 proof using public inputs

--- a/g16ckt/src/gadgets/groth16.rs
+++ b/g16ckt/src/gadgets/groth16.rs
@@ -6,7 +6,7 @@
 
 use ark_bn254::Bn254;
 use ark_ec::{AffineRepr, pairing::Pairing};
-use ark_ff::Field;
+use ark_ff::{Field, PrimeField};
 use ark_groth16::VerifyingKey;
 use ark_serialize::CanonicalSerialize;
 use circuit_component_macro::component;
@@ -14,9 +14,9 @@ use num_bigint::BigUint;
 
 use crate::{
     CircuitContext, WireId,
-    circuit::{CircuitInput, CircuitMode, EncodeInput, WiresObject},
+    circuit::{CircuitInput, CircuitMode, EncodeInput, TRUE_WIRE, WiresObject},
     gadgets::{
-        bigint::BigIntWires,
+        bigint::{self, BigIntWires},
         bn254::{
             G2Projective, final_exponentiation::final_exponentiation_montgomery, fq::Fq,
             fq12::Fq12, fr::Fr, g1::G1Projective,
@@ -68,26 +68,87 @@ pub fn groth16_verify<C: CircuitContext>(
         vk,
     } = input;
 
-    let proof_is_on_curve = {
-        let a_is_on_curve = G1Projective::is_on_curve(circuit, a);
-        let b_is_on_curve = G2Projective::is_on_curve(circuit, b);
-        let c_is_on_curve = G1Projective::is_on_curve(circuit, c);
+    let is_valid_field_and_group = {
+        let is_valid_fr = {
+            let mut and_all_wires = TRUE_WIRE;
+            public.iter().for_each(|pubinp| {
+                let r: BigUint = ark_bn254::Fr::MODULUS.into();
+                let valid_pubinp = bigint::less_than_constant(circuit, pubinp, &r);
+                let new_wire = circuit.issue_wire();
+                circuit.add_gate(crate::Gate {
+                    wire_a: and_all_wires,
+                    wire_b: valid_pubinp,
+                    wire_c: new_wire,
+                    gate_type: crate::GateType::And,
+                });
+                and_all_wires = new_wire;
+            });
+            and_all_wires
+        };
 
-        let tmp0 = circuit.issue_wire();
-        let tmp1 = circuit.issue_wire();
+        // Verify that all group elements of input proof include valid base field elements
+        let is_valid_fq = {
+            let elems = [
+                &a.x, &a.y, &a.z, &b.x.0[0], &b.x.0[1], &b.y.0[0], &b.y.0[1], &b.z.0[0], &b.z.0[1],
+                &c.x, &c.y, &c.z,
+            ];
+            let mut and_all_wires = TRUE_WIRE;
+            elems.iter().for_each(|pubinp| {
+                let r: BigUint = ark_bn254::Fq::MODULUS.into();
+                let valid_fq = bigint::less_than_constant(circuit, pubinp, &r);
+                let new_wire = circuit.issue_wire();
+                circuit.add_gate(crate::Gate {
+                    wire_a: and_all_wires,
+                    wire_b: valid_fq,
+                    wire_c: new_wire,
+                    gate_type: crate::GateType::And,
+                });
+                and_all_wires = new_wire;
+            });
+            and_all_wires
+        };
+
+        let is_on_curve = {
+            let a_is_on_curve = G1Projective::is_on_curve(circuit, a);
+            let b_is_on_curve = G2Projective::is_on_curve(circuit, b);
+            let c_is_on_curve = G1Projective::is_on_curve(circuit, c);
+
+            // valid group check
+            let tmp0 = circuit.issue_wire();
+            let is_on_curve = circuit.issue_wire();
+            circuit.add_gate(crate::Gate {
+                wire_a: a_is_on_curve,
+                wire_b: b_is_on_curve,
+                wire_c: tmp0,
+                gate_type: crate::GateType::And,
+            });
+            circuit.add_gate(crate::Gate {
+                wire_a: tmp0,
+                wire_b: c_is_on_curve,
+                wire_c: is_on_curve,
+                gate_type: crate::GateType::And,
+            });
+            is_on_curve
+        };
+
+        // valid fq and fr
+        let is_valid_field = circuit.issue_wire();
         circuit.add_gate(crate::Gate {
-            wire_a: a_is_on_curve,
-            wire_b: b_is_on_curve,
-            wire_c: tmp0,
+            wire_a: is_valid_fr,
+            wire_b: is_valid_fq,
+            wire_c: is_valid_field,
             gate_type: crate::GateType::And,
         });
+
+        // valid field and group check
+        let is_valid_field_and_group = circuit.issue_wire();
         circuit.add_gate(crate::Gate {
-            wire_a: tmp0,
-            wire_b: c_is_on_curve,
-            wire_c: tmp1,
+            wire_a: is_valid_field,
+            wire_b: is_on_curve,
+            wire_c: is_valid_field_and_group,
             gate_type: crate::GateType::And,
         });
-        tmp1
+        is_valid_field_and_group
     };
 
     // Standard verification with public inputs
@@ -135,7 +196,7 @@ pub fn groth16_verify<C: CircuitContext>(
     let valid = circuit.issue_wire();
     circuit.add_gate(crate::Gate {
         wire_a: finexp_match,
-        wire_b: proof_is_on_curve,
+        wire_b: is_valid_field_and_group,
         wire_c: valid,
         gate_type: crate::GateType::And,
     });

--- a/g16ckt/src/gadgets/groth16.rs
+++ b/g16ckt/src/gadgets/groth16.rs
@@ -5,24 +5,21 @@
 //! where `msm = vk.gamma_abc_g1[0] + sum_i(public[i] * vk.gamma_abc_g1[i+1])`.
 
 use ark_bn254::Bn254;
-use ark_ec::{AffineRepr, CurveGroup, models::short_weierstrass::SWCurveConfig, pairing::Pairing};
-use ark_ff::{AdditiveGroup, Field};
+use ark_ec::{AffineRepr, pairing::Pairing};
+use ark_ff::Field;
 use ark_groth16::VerifyingKey;
+use ark_serialize::CanonicalSerialize;
 use circuit_component_macro::component;
+use num_bigint::BigUint;
 
 use crate::{
-    CircuitContext, Fq2Wire, WireId,
+    CircuitContext, WireId,
     circuit::{CircuitInput, CircuitMode, EncodeInput, WiresObject},
     gadgets::{
-        bigint,
+        bigint::BigIntWires,
         bn254::{
-            G2Projective,
-            final_exponentiation::final_exponentiation_montgomery,
-            fq::Fq,
-            fq12::Fq12,
-            fr::Fr,
-            g1::{DecompressedG1Wires, G1Projective},
-            g2::DecompressedG2Wires,
+            G2Projective, final_exponentiation::final_exponentiation_montgomery, fq::Fq,
+            fq12::Fq12, fr::Fr, g1::G1Projective,
             pairing::multi_miller_loop_groth16_evaluate_montgomery_fast,
         },
     },
@@ -114,202 +111,21 @@ pub fn groth16_verify<C: CircuitContext>(
     Fq12::equal_constant(circuit, &f, &Fq12::as_montgomery(alpha_beta))
 }
 
-/// Decompress a compressed G1 point (x, sign bit) into projective wires with z = 1 (Montgomery domain).
-/// - `x_m`: x-coordinate in Montgomery form wires
-/// - `y_flag`: boolean wire selecting the correct sqrt branch for y
-#[component]
-pub fn decompress_g1_from_compressed<C: CircuitContext>(
-    circuit: &mut C,
-    compressed: &CompressedG1Wires,
-) -> DecompressedG1Wires {
-    let CompressedG1Wires { x_m, y_flag } = compressed.clone();
-
-    // rhs = x^3 + b (Montgomery domain)
-    let x2 = Fq::square_montgomery(circuit, &x_m);
-    let x3 = Fq::mul_montgomery(circuit, &x2, &x_m);
-    let b_m = Fq::as_montgomery(ark_bn254::g1::Config::COEFF_B);
-    let rhs = Fq::add_constant(circuit, &x3, &b_m);
-
-    // sy = sqrt(rhs) in Montgomery domain
-    let sy = Fq::sqrt_montgomery(circuit, &rhs);
-    // check if sy * sy == rhs to ensure rhs was a quadratic residue to begin with
-    let sy_sy = Fq::square_montgomery(circuit, &sy);
-    let rhs_is_qr = bigint::equal(circuit, &sy_sy, &rhs);
-
-    let sy_neg = Fq::neg(circuit, &sy);
-    let y_bits = bigint::select(circuit, &sy.0, &sy_neg.0, y_flag);
-    let y = Fq(y_bits);
-
-    // z = 1 in Montgomery
-    let one_m = Fq::as_montgomery(ark_bn254::Fq::ONE);
-    let z = Fq::new_constant(&one_m).expect("const one mont");
-
-    DecompressedG1Wires {
-        point: G1Projective {
-            x: x_m.clone(),
-            y,
-            z,
-        },
-        is_valid: rhs_is_qr,
-    }
-}
-
-#[component]
-pub fn decompress_g2_from_compressed<C: CircuitContext>(
-    circuit: &mut C,
-    compressed: &CompressedG2Wires,
-) -> DecompressedG2Wires {
-    let CompressedG2Wires { p: x, y_flag } = compressed;
-
-    let x2 = Fq2Wire::square_montgomery(circuit, x);
-
-    let x3 = Fq2Wire::mul_montgomery(circuit, &x2, x);
-
-    let y2 = Fq2Wire::add_constant(
-        circuit,
-        &x3,
-        &Fq2Wire::as_montgomery(ark_bn254::g2::Config::COEFF_B),
-    );
-
-    let y = Fq2Wire::sqrt_general_montgomery(circuit, &y2);
-    let rhs_is_qr = {
-        // check if y * y == y2 to ensure rhs was a quadratic residue to begin with
-        let y_y = Fq2Wire::square_montgomery(circuit, &y);
-
-        let match_c0 = bigint::equal(circuit, y2.c0(), y_y.c0());
-        let match_c1 = bigint::equal(circuit, y2.c1(), y_y.c1());
-        let match_c0_and_c1 = circuit.issue_wire();
-        circuit.add_gate(crate::Gate {
-            wire_a: match_c0,
-            wire_b: match_c1,
-            wire_c: match_c0_and_c1,
-            gate_type: crate::GateType::And,
-        });
-        match_c0_and_c1
-    };
-
-    let neg_y = Fq2Wire::neg(circuit, y.clone());
-
-    let final_y_0 = bigint::select(circuit, y.c0(), neg_y.c0(), *y_flag);
-    let final_y_1 = bigint::select(circuit, y.c1(), neg_y.c1(), *y_flag);
-
-    // z = 1 in Montgomery
-    let one_m = Fq::as_montgomery(ark_bn254::Fq::ONE);
-    let one_m = Fq::new_constant(&one_m).expect("const one mont");
-    let zero_m = Fq::as_montgomery(ark_bn254::Fq::ZERO);
-    let zero_m = Fq::new_constant(&zero_m).expect("const zero mont");
-
-    DecompressedG2Wires {
-        point: G2Projective {
-            x: x.clone(),
-            y: Fq2Wire([Fq(final_y_0), Fq(final_y_1)]),
-            // In Fq2, ONE is (c0=1, c1=0). Use Montgomery representation.
-            z: Fq2Wire([one_m, zero_m]),
-        },
-        is_valid: rhs_is_qr,
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct CompressedG1Wires {
-    pub x_m: Fq,
-    pub y_flag: WireId,
-}
-
-impl CompressedG1Wires {
-    pub fn new(mut issue: impl FnMut() -> WireId) -> Self {
-        Self {
-            x_m: Fq::new(&mut issue),
-            y_flag: issue(),
-        }
-    }
-}
-
-impl WiresObject for CompressedG1Wires {
-    fn to_wires_vec(&self) -> Vec<WireId> {
-        let Self { x_m: p, y_flag } = self;
-
-        let mut v = p.to_wires_vec();
-        v.push(*y_flag);
-        v
-    }
-
-    fn clone_from(&self, wire_gen: &mut impl FnMut() -> WireId) -> Self {
-        Self {
-            x_m: self.x_m.clone_from(wire_gen),
-            y_flag: self.y_flag.clone_from(wire_gen),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct CompressedG2Wires {
-    pub p: Fq2Wire,
-    pub y_flag: WireId,
-}
-
-impl CompressedG2Wires {
-    pub fn new(mut issue: impl FnMut() -> WireId) -> Self {
-        Self {
-            p: Fq2Wire::new(&mut issue),
-            y_flag: issue(),
-        }
-    }
-}
-
-impl WiresObject for CompressedG2Wires {
-    fn to_wires_vec(&self) -> Vec<WireId> {
-        let Self { p, y_flag } = self;
-
-        let mut v = p.to_wires_vec();
-        v.push(*y_flag);
-        v
-    }
-
-    fn clone_from(&self, wire_gen: &mut impl FnMut() -> WireId) -> Self {
-        Self {
-            p: self.p.clone_from(wire_gen),
-            y_flag: self.y_flag.clone_from(wire_gen),
-        }
-    }
-}
-
 /// Convenience wrapper: verify using compressed A and C (x, y_flag). B remains host-provided `G2Affine`.
 /// Includes optimization for empty public inputs to avoid unnecessary MSM computation.
 pub fn groth16_verify_compressed<C: CircuitContext>(
     circuit: &mut C,
     input: &Groth16VerifyCompressedInputWires,
 ) -> crate::WireId {
-    let a = decompress_g1_from_compressed(circuit, &input.a);
-    let b = decompress_g2_from_compressed(circuit, &input.b);
-    let c = decompress_g1_from_compressed(circuit, &input.c);
-
-    let valid_decompressed = {
-        let tmp0 = circuit.issue_wire();
-        let tmp1 = circuit.issue_wire();
-
-        circuit.add_gate(crate::Gate {
-            wire_a: a.is_valid,
-            wire_b: b.is_valid,
-            wire_c: tmp0,
-            gate_type: crate::GateType::And,
-        });
-        circuit.add_gate(crate::Gate {
-            wire_a: tmp0,
-            wire_b: c.is_valid,
-            wire_c: tmp1,
-            gate_type: crate::GateType::And,
-        });
-        tmp1
-    };
+    let proof = input.proof.deserialize_checked(circuit);
 
     let verified_res = groth16_verify(
         circuit,
         &Groth16VerifyInputWires {
             public: input.public.clone(),
-            a: a.point,
-            b: b.point,
-            c: c.point,
+            a: proof.a,
+            b: proof.b,
+            c: proof.c,
             vk: input.vk.clone(),
         },
     );
@@ -317,7 +133,7 @@ pub fn groth16_verify_compressed<C: CircuitContext>(
     let valid = circuit.issue_wire();
     circuit.add_gate(crate::Gate {
         wire_a: verified_res,
-        wire_b: valid_decompressed,
+        wire_b: proof.valid,
         wire_c: valid,
         gate_type: crate::GateType::And,
     });
@@ -427,19 +243,103 @@ impl<M: CircuitMode<WireValue = bool>> EncodeInput<M> for Groth16VerifyInput {
 
 impl Groth16VerifyInput {
     pub fn compress(self) -> Groth16VerifyCompressedInput {
-        Groth16VerifyCompressedInput(self)
+        let public = self.public.into_iter().map(|x| x.into()).collect();
+        let mut proof_bytes = Vec::new();
+        ark_groth16::Proof::<Bn254> {
+            a: self.a.into(),
+            b: self.b.into(),
+            c: self.c.into(),
+        }
+        .serialize_compressed(&mut proof_bytes)
+        .expect("serialize proof");
+        let proof_bits: Vec<bool> = proof_bytes
+            .iter()
+            .flat_map(|&b| (0..8).map(move |i| ((b >> i) & 1) == 1))
+            .collect();
+        Groth16VerifyCompressedInput {
+            public,
+            proof: proof_bits.try_into().unwrap(),
+            vk: self.vk,
+        }
     }
 }
 
-pub struct Groth16VerifyCompressedInput(pub Groth16VerifyInput);
+type SerializedCompressedProof = [bool; 128 * 8];
+/// Compressed representation of groth16 proof
+pub struct Groth16VerifyCompressedInput {
+    pub public: Vec<BigUint>,
+    pub proof: SerializedCompressedProof, // 128 byte proof
+    pub vk: VerifyingKey<Bn254>,
+}
 
 #[derive(Debug)]
 pub struct Groth16VerifyCompressedInputWires {
     pub public: Vec<Fr>,
-    pub a: CompressedG1Wires,
-    pub b: CompressedG2Wires,
-    pub c: CompressedG1Wires,
+    pub proof: SerializedCompressedProofWires,
     pub vk: VerifyingKey<Bn254>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SerializedCompressedProofWires(pub [WireId; 128 * 8]);
+
+#[derive(Debug, Clone)]
+pub struct DeserializedCompressedProofWires {
+    a: G1Projective,
+    b: G2Projective,
+    c: G1Projective,
+    valid: WireId,
+}
+
+impl SerializedCompressedProofWires {
+    pub fn new(issue: &mut impl FnMut() -> WireId) -> Self {
+        let v: Vec<WireId> = std::iter::repeat_with(issue).take(128 * 8).collect();
+        let v: [WireId; 128 * 8] = v.try_into().unwrap();
+        Self(v)
+    }
+    pub fn deserialize_checked<C: CircuitContext>(
+        &self,
+        circuit: &mut C,
+    ) -> DeserializedCompressedProofWires {
+        let compressed_a: [WireId; 32 * 8] = self.0[0..32 * 8].try_into().unwrap();
+        let compressed_b: [WireId; 64 * 8] = self.0[32 * 8..96 * 8].try_into().unwrap();
+        let compressed_c: [WireId; 32 * 8] = self.0[96 * 8..].try_into().unwrap();
+
+        let a_decomp = G1Projective::deserialize_checked(circuit, compressed_a);
+        let b_decomp = G2Projective::deserialize_checked(circuit, compressed_b);
+        let c_decomp = G1Projective::deserialize_checked(circuit, compressed_c);
+
+        let ab_valid = circuit.issue_wire();
+        let abc_valid = circuit.issue_wire();
+
+        circuit.add_gate(crate::Gate {
+            wire_a: a_decomp.is_valid,
+            wire_b: b_decomp.is_valid,
+            wire_c: ab_valid,
+            gate_type: crate::GateType::And,
+        });
+        circuit.add_gate(crate::Gate {
+            wire_a: ab_valid,
+            wire_b: c_decomp.is_valid,
+            wire_c: abc_valid,
+            gate_type: crate::GateType::And,
+        });
+
+        DeserializedCompressedProofWires {
+            a: a_decomp.point,
+            b: b_decomp.point,
+            c: c_decomp.point,
+            valid: abc_valid,
+        }
+    }
+}
+
+impl WiresObject for SerializedCompressedProofWires {
+    fn to_wires_vec(&self) -> Vec<WireId> {
+        self.0.to_vec()
+    }
+    fn clone_from(&self, wire_gen: &mut impl FnMut() -> WireId) -> Self {
+        SerializedCompressedProofWires::new(wire_gen)
+    }
 }
 
 impl WiresObject for Groth16VerifyCompressedInputWires {
@@ -450,9 +350,7 @@ impl WiresObject for Groth16VerifyCompressedInputWires {
     fn clone_from(&self, mut issue: &mut impl FnMut() -> WireId) -> Self {
         Groth16VerifyCompressedInputWires {
             public: self.public.iter().map(|_| Fr::new(&mut issue)).collect(),
-            a: CompressedG1Wires::new(&mut issue),
-            b: CompressedG2Wires::new(&mut issue),
-            c: CompressedG1Wires::new(&mut issue),
+            proof: self.proof.clone_from(issue),
             vk: self.vk.clone(),
         }
     }
@@ -463,11 +361,9 @@ impl CircuitInput for Groth16VerifyCompressedInput {
 
     fn allocate(&self, mut issue: impl FnMut() -> WireId) -> Self::WireRepr {
         Groth16VerifyCompressedInputWires {
-            public: self.0.public.iter().map(|_| Fr::new(&mut issue)).collect(),
-            a: CompressedG1Wires::new(&mut issue),
-            b: CompressedG2Wires::new(&mut issue),
-            c: CompressedG1Wires::new(&mut issue),
-            vk: self.0.vk.clone(),
+            public: self.public.iter().map(|_| Fr::new(&mut issue)).collect(),
+            proof: SerializedCompressedProofWires::new(&mut issue),
+            vk: self.vk.clone(),
         }
     }
     fn collect_wire_ids(repr: &Self::WireRepr) -> Vec<crate::WireId> {
@@ -475,9 +371,7 @@ impl CircuitInput for Groth16VerifyCompressedInput {
         for s in &repr.public {
             ids.extend(s.to_wires_vec());
         }
-        ids.extend(repr.a.to_wires_vec());
-        ids.extend(repr.b.to_wires_vec());
-        ids.extend(repr.c.to_wires_vec());
+        ids.extend(repr.proof.to_wires_vec());
         ids
     }
 }
@@ -485,8 +379,8 @@ impl CircuitInput for Groth16VerifyCompressedInput {
 impl<M: CircuitMode<WireValue = bool>> EncodeInput<M> for Groth16VerifyCompressedInput {
     fn encode(&self, repr: &Groth16VerifyCompressedInputWires, cache: &mut M) {
         // Encode public scalars
-        for (w, v) in repr.public.iter().zip(self.0.public.iter()) {
-            let fr_fn = Fr::get_wire_bits_fn(w, v).unwrap();
+        for (w, v) in repr.public.iter().zip(self.public.iter()) {
+            let fr_fn = BigIntWires::get_wire_bits_fn(w, v).unwrap();
 
             for &wire in w.iter() {
                 if let Some(bit) = fr_fn(wire) {
@@ -495,73 +389,32 @@ impl<M: CircuitMode<WireValue = bool>> EncodeInput<M> for Groth16VerifyCompresse
             }
         }
 
-        // Compute compression from standard affine coords; feed Montgomery x + flag
-        let a_aff_std = self.0.a.into_affine();
-        let b_aff_std = self.0.b.into_affine();
-        let c_aff_std = self.0.c.into_affine();
-
-        let a_flag = (a_aff_std.y.square())
-            .sqrt()
-            .expect("y^2 must be QR")
-            .eq(&a_aff_std.y);
-        let b_flag = (b_aff_std.y.square())
-            .sqrt()
-            .expect("y^2 must be QR in Fq2")
-            .eq(&b_aff_std.y);
-        let c_flag = (c_aff_std.y.square())
-            .sqrt()
-            .expect("y^2 must be QR")
-            .eq(&c_aff_std.y);
-
-        let a_x_m = Fq::as_montgomery(a_aff_std.x);
-        let b_x_m = Fq2Wire::as_montgomery(b_aff_std.x);
-        let c_x_m = Fq::as_montgomery(c_aff_std.x);
-
-        // Feed A.x (Montgomery) bits and flag
-        let a_x_fn = Fq::get_wire_bits_fn(&repr.a.x_m, &a_x_m).unwrap();
-        for &wire_id in repr.a.x_m.iter() {
-            if let Some(bit) = a_x_fn(wire_id) {
-                cache.feed_wire(wire_id, bit);
-            }
-        }
-        cache.feed_wire(repr.a.y_flag, a_flag);
-
-        // Feed B.x (Montgomery) bits and flag (Fq2 as c0||c1)
-        let b_x_fn = Fq2Wire::get_wire_bits_fn(&repr.b.p, &b_x_m).unwrap();
-        for &wire_id in repr.b.p.iter() {
-            if let Some(bit) = b_x_fn(wire_id) {
-                cache.feed_wire(wire_id, bit);
-            }
-        }
-        cache.feed_wire(repr.b.y_flag, b_flag);
-
-        // Feed C.x (Montgomery) bits and flag
-        let c_x_fn = Fq::get_wire_bits_fn(&repr.c.x_m, &c_x_m).unwrap();
-        for &wire_id in repr.c.x_m.iter() {
-            if let Some(bit) = c_x_fn(wire_id) {
-                cache.feed_wire(wire_id, bit);
-            }
-        }
-        cache.feed_wire(repr.c.y_flag, c_flag);
+        self.proof.iter().zip(repr.proof.0).for_each(|(x, y)| {
+            cache.feed_wire(y, *x);
+        });
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use ark_ec::{AffineRepr, CurveGroup, PrimeGroup};
+    use ark_ec::{AffineRepr, CurveGroup, PrimeGroup, short_weierstrass::SWCurveConfig};
     use ark_ff::UniformRand;
     use ark_groth16::Groth16;
     use ark_relations::{
         lc,
         r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError},
     };
+    use ark_serialize::CanonicalDeserialize;
     use ark_snark::{CircuitSpecificSetupSNARK, SNARK};
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha20Rng;
     use test_log::test;
 
     use super::*;
-    use crate::circuit::{CircuitBuilder, CircuitMode, EncodeInput, StreamingResult};
+    use crate::{
+        Fq2Wire,
+        circuit::{CircuitBuilder, StreamingResult},
+    };
 
     // Helper to reduce duplication across bitflip tests for A, B, and C
     fn run_false_bitflip_test(seed: u64, mutate: impl FnOnce(&mut Groth16VerifyInput)) {
@@ -878,174 +731,6 @@ mod tests {
         assert!(!out.output_value);
     }
 
-    // Minimal harnesses that allocate compressed wires and feed them directly
-    struct OnlyCompressedG1Input(ark_bn254::G1Affine);
-    impl crate::circuit::CircuitInput for OnlyCompressedG1Input {
-        type WireRepr = CompressedG1Wires;
-        fn allocate(&self, mut issue: impl FnMut() -> WireId) -> Self::WireRepr {
-            CompressedG1Wires::new(&mut issue)
-        }
-        fn collect_wire_ids(repr: &Self::WireRepr) -> Vec<WireId> {
-            repr.to_wires_vec()
-        }
-    }
-    impl<M: CircuitMode<WireValue = bool>> EncodeInput<M> for OnlyCompressedG1Input {
-        fn encode(&self, repr: &CompressedG1Wires, cache: &mut M) {
-            let p = self.0;
-            let x_m = Fq::as_montgomery(p.x);
-            let s = (p.y.square()).sqrt().expect("y^2 must be QR");
-            let y_flag = s == p.y;
-
-            let x_fn = Fq::get_wire_bits_fn(&repr.x_m, &x_m).unwrap();
-            for &w in repr.x_m.iter() {
-                if let Some(bit) = x_fn(w) {
-                    cache.feed_wire(w, bit);
-                }
-            }
-            cache.feed_wire(repr.y_flag, y_flag);
-        }
-    }
-
-    struct OnlyCompressedG2Input(ark_bn254::G2Affine);
-    impl crate::circuit::CircuitInput for OnlyCompressedG2Input {
-        type WireRepr = CompressedG2Wires;
-        fn allocate(&self, mut issue: impl FnMut() -> WireId) -> Self::WireRepr {
-            CompressedG2Wires::new(&mut issue)
-        }
-        fn collect_wire_ids(repr: &Self::WireRepr) -> Vec<WireId> {
-            repr.to_wires_vec()
-        }
-    }
-    impl<M: CircuitMode<WireValue = bool>> EncodeInput<M> for OnlyCompressedG2Input {
-        fn encode(&self, repr: &CompressedG2Wires, cache: &mut M) {
-            let p = self.0;
-            let x_m = Fq2Wire::as_montgomery(p.x);
-            // Simple off-circuit compression flag: sqrt(y^2) == y
-            let s = (p.y.square()).sqrt().expect("y^2 must be QR in Fq2");
-            let y_flag = s == p.y;
-
-            let x_fn = Fq2Wire::get_wire_bits_fn(&repr.p, &x_m).unwrap();
-            for &w in repr.p.iter() {
-                if let Some(bit) = x_fn(w) {
-                    cache.feed_wire(w, bit);
-                }
-            }
-            cache.feed_wire(repr.y_flag, y_flag);
-        }
-    }
-
-    #[test]
-    fn test_g1_compress_decompress_matches() {
-        let mut rng = ChaCha20Rng::seed_from_u64(111);
-        let r = ark_bn254::Fr::rand(&mut rng);
-        let p = (ark_bn254::G1Projective::generator() * r).into_affine();
-
-        let input = OnlyCompressedG1Input(p);
-
-        let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
-            CircuitBuilder::streaming_execute(input, 10_000, |ctx, wires| {
-                let res = decompress_g1_from_compressed(ctx, wires);
-                let dec = res.point;
-
-                let exp = G1Projective::as_montgomery(p.into_group());
-                let x_ok = Fq::equal_constant(ctx, &dec.x, &exp.x);
-                let z_ok = Fq::equal_constant(ctx, &dec.z, &exp.z);
-                // Compare y up to sign by checking y^2 equality
-                let y_sq = Fq::square_montgomery(ctx, &dec.y);
-                let exp_y_std = Fq::from_montgomery(exp.y);
-                let exp_y_sq_m = Fq::as_montgomery(exp_y_std.square());
-                let y_ok = Fq::equal_constant(ctx, &y_sq, &exp_y_sq_m);
-                vec![x_ok, y_ok, z_ok, res.is_valid]
-            });
-
-        assert!(out.output_value.iter().all(|&b| b));
-    }
-
-    #[test]
-    fn test_g1_decompress_failure() {
-        let mut rng = ChaCha20Rng::seed_from_u64(112);
-        for _ in 0..5 {
-            // sufficient sample size to sample both valid and invalid points
-            let x = ark_bn254::Fq::rand(&mut rng);
-            let a1 = ark_bn254::Fq::sqrt(&((x * x * x) + ark_bn254::Fq::from(3)));
-            let (y, ref_is_valid) = if let Some(a1) = a1 {
-                // if it is possible to take square root, you have found correct y,
-                (a1, true)
-            } else {
-                // else generate some random value
-                (ark_bn254::Fq::rand(&mut rng), false)
-            };
-            let pt = ark_bn254::G1Affine::new_unchecked(x, y);
-
-            let input = OnlyCompressedG1Input(pt);
-            let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
-                CircuitBuilder::streaming_execute(input, 10_000, |ctx, wires| {
-                    let dec = decompress_g1_from_compressed(ctx, wires);
-                    vec![dec.is_valid]
-                });
-            let calc_is_valid = out.output_value[0];
-
-            assert_eq!(calc_is_valid, ref_is_valid);
-            assert_eq!(calc_is_valid, pt.is_on_curve());
-        }
-    }
-
-    #[test]
-    fn test_g2_compress_decompress_matches() {
-        let mut rng = ChaCha20Rng::seed_from_u64(222);
-        let r = ark_bn254::Fr::rand(&mut rng);
-        let p = (ark_bn254::G2Projective::generator() * r).into_affine();
-
-        let input = OnlyCompressedG2Input(p);
-
-        let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
-            CircuitBuilder::streaming_execute(input, 20_000, |ctx, wires| {
-                let res = decompress_g2_from_compressed(ctx, wires);
-                let dec = res.point;
-
-                let exp = G2Projective::as_montgomery(p.into_group());
-                let x_ok = Fq2Wire::equal_constant(ctx, &dec.x, &exp.x);
-                let z_ok = Fq2Wire::equal_constant(ctx, &dec.z, &exp.z);
-                // Compare y up to sign by checking y^2 equality
-                let y_sq = Fq2Wire::square_montgomery(ctx, &dec.y);
-                let exp_y_std = Fq2Wire::from_montgomery(exp.y);
-                let exp_y_sq_m = Fq2Wire::as_montgomery(exp_y_std.square());
-                let y_ok = Fq2Wire::equal_constant(ctx, &y_sq, &exp_y_sq_m);
-                vec![x_ok, y_ok, z_ok, res.is_valid]
-            });
-
-        assert!(out.output_value.iter().all(|&b| b));
-    }
-
-    #[test]
-    fn test_g2_decompress_failure() {
-        let mut rng = ChaCha20Rng::seed_from_u64(112);
-        for _ in 0..5 {
-            // sufficient sample size to sample both valid and invalid points
-            let x = ark_bn254::Fq2::rand(&mut rng);
-            let a1 = ark_bn254::Fq2::sqrt(&((x * x * x) + ark_bn254::g2::Config::COEFF_B));
-            let (y, ref_is_valid) = if let Some(a1) = a1 {
-                // if it is possible to take square root, you have found correct y,
-                (a1, true)
-            } else {
-                // else generate some random value
-                (ark_bn254::Fq2::rand(&mut rng), false)
-            };
-            let pt = ark_bn254::G2Affine::new_unchecked(x, y);
-
-            let input = OnlyCompressedG2Input(pt);
-            let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
-                CircuitBuilder::streaming_execute(input, 10_000, |ctx, wires| {
-                    let dec = decompress_g2_from_compressed(ctx, wires);
-                    vec![dec.is_valid]
-                });
-            let calc_is_valid = out.output_value[0];
-
-            assert_eq!(calc_is_valid, ref_is_valid);
-            assert_eq!(calc_is_valid, pt.is_on_curve());
-        }
-    }
-
     #[test]
     fn test_cofactor_clearing() {
         let mut rng = ChaCha20Rng::seed_from_u64(112);
@@ -1092,23 +777,22 @@ mod tests {
         let (pk, vk) = Groth16::<ark_bn254::Bn254>::setup(circuit, &mut rng).unwrap();
         let proof = Groth16::<ark_bn254::Bn254>::prove(&pk, circuit, &mut rng).unwrap();
 
-        let inputs = Groth16VerifyCompressedInput(Groth16VerifyInput {
+        let inputs = Groth16VerifyInput {
             public: vec![ark_bn254::Fr::from(0u64)], // unused here
             a: proof.a.into_group(),
             b: proof.b.into_group(),
             c: proof.c.into_group(),
             vk,
-        });
+        }
+        .compress();
 
         let out: crate::circuit::StreamingResult<_, _, Vec<bool>> =
             CircuitBuilder::streaming_execute(inputs, 80_000, |ctx, wires| {
-                let a = decompress_g1_from_compressed(ctx, &wires.a);
-                let b = decompress_g2_from_compressed(ctx, &wires.b);
-                let c = decompress_g1_from_compressed(ctx, &wires.c);
+                let proof_dec = wires.proof.deserialize_checked(ctx);
 
-                let a_dec = a.point;
-                let b_dec = b.point;
-                let c_dec = c.point;
+                let a_dec = proof_dec.a;
+                let b_dec = proof_dec.b;
+                let c_dec = proof_dec.c;
 
                 let a_exp = G1Projective::as_montgomery(proof.a.into_group());
                 let b_exp = G2Projective::as_montgomery(proof.b.into_group());
@@ -1127,8 +811,16 @@ mod tests {
                 let c_z_ok = Fq::equal_constant(ctx, &c_dec.z, &c_exp.z);
 
                 vec![
-                    a_x_ok, a_y_ok, a_z_ok, b_x_ok, b_y_ok, b_z_ok, c_x_ok, c_y_ok, c_z_ok,
-                    a.is_valid, b.is_valid, c.is_valid,
+                    a_x_ok,
+                    a_y_ok,
+                    a_z_ok,
+                    b_x_ok,
+                    b_y_ok,
+                    b_z_ok,
+                    c_x_ok,
+                    c_y_ok,
+                    c_z_ok,
+                    proof_dec.valid,
                 ]
             });
 
@@ -1343,5 +1035,47 @@ mod tests {
         assert!(!run_small_verify(VerifyFlow::Compressed, 80808, |inputs| {
             inputs.c.x += ark_bn254::Fq::ONE;
         }));
+    }
+
+    #[test]
+    fn test_ark_proof_decompress_matches() {
+        let ark_proof_bytes: [u8; 128] = [
+            55, 126, 31, 52, 68, 72, 45, 185, 179, 42, 69, 122, 227, 134, 234, 167, 80, 68, 65,
+            142, 134, 133, 97, 24, 194, 180, 193, 213, 111, 19, 12, 42, 142, 193, 123, 63, 163, 6,
+            122, 100, 126, 178, 41, 127, 97, 82, 169, 2, 30, 190, 130, 153, 110, 203, 2, 95, 89,
+            162, 70, 74, 63, 232, 176, 42, 39, 119, 13, 172, 154, 135, 98, 126, 217, 67, 36, 222,
+            136, 93, 161, 93, 1, 196, 101, 172, 163, 240, 105, 124, 107, 93, 222, 133, 118, 94,
+            161, 14, 165, 232, 61, 136, 121, 145, 0, 171, 184, 234, 57, 160, 1, 248, 7, 195, 124,
+            95, 50, 113, 24, 203, 211, 73, 196, 40, 173, 148, 179, 126, 12, 131,
+        ];
+        let ark_proof = ark_groth16::Proof::<ark_bn254::Bn254>::deserialize_compressed_unchecked(
+            &ark_proof_bytes[..],
+        )
+        .unwrap();
+        let ark_proof_bits: Vec<bool> = ark_proof_bytes
+            .iter()
+            .flat_map(|&b| (0..8).map(move |i| ((b >> i) & 1) == 1))
+            .collect();
+
+        let inputs = Groth16VerifyCompressedInput {
+            public: vec![],
+            proof: ark_proof_bits.try_into().unwrap(),
+            vk: ark_groth16::VerifyingKey::default(),
+        };
+
+        let result: StreamingResult<_, _, Vec<bool>> =
+            CircuitBuilder::streaming_execute(inputs, 80_000, |ctx, wires| {
+                let result_wires = wires.proof.deserialize_checked(ctx).b;
+                let mut output_ids = Vec::new();
+                output_ids.extend(result_wires.x.iter());
+                output_ids.extend(result_wires.y.iter());
+                output_ids.extend(result_wires.z.iter());
+                output_ids
+            });
+
+        let actual_result = G2Projective::from_bits_unchecked(result.output_value.clone());
+
+        let ark_proof_a_mont = G2Projective::as_montgomery(ark_proof.b.into());
+        assert_eq!(actual_result, ark_proof_a_mont);
     }
 }

--- a/g16ckt/src/gadgets/groth16.rs
+++ b/g16ckt/src/gadgets/groth16.rs
@@ -72,8 +72,8 @@ pub fn groth16_verify<C: CircuitContext>(
         let is_valid_fr = {
             let mut and_all_wires = TRUE_WIRE;
             public.iter().for_each(|pubinp| {
-                let r: BigUint = ark_bn254::Fr::MODULUS.into();
-                let valid_pubinp = bigint::less_than_constant(circuit, pubinp, &r);
+                let q: BigUint = ark_bn254::Fr::MODULUS.into();
+                let valid_pubinp = bigint::less_than_constant(circuit, pubinp, &q);
                 let new_wire = circuit.issue_wire();
                 circuit.add_gate(crate::Gate {
                     wire_a: and_all_wires,

--- a/g16ckt/src/gadgets/groth16.rs
+++ b/g16ckt/src/gadgets/groth16.rs
@@ -72,8 +72,8 @@ pub fn groth16_verify<C: CircuitContext>(
         let is_valid_fr = {
             let mut and_all_wires = TRUE_WIRE;
             public.iter().for_each(|pubinp| {
-                let q: BigUint = ark_bn254::Fr::MODULUS.into();
-                let valid_pubinp = bigint::less_than_constant(circuit, pubinp, &q);
+                let r: BigUint = ark_bn254::Fr::MODULUS.into();
+                let valid_pubinp = bigint::less_than_constant(circuit, pubinp, &r);
                 let new_wire = circuit.issue_wire();
                 circuit.add_gate(crate::Gate {
                     wire_a: and_all_wires,
@@ -94,8 +94,8 @@ pub fn groth16_verify<C: CircuitContext>(
             ];
             let mut and_all_wires = TRUE_WIRE;
             elems.iter().for_each(|pubinp| {
-                let r: BigUint = ark_bn254::Fq::MODULUS.into();
-                let valid_fq = bigint::less_than_constant(circuit, pubinp, &r);
+                let q: BigUint = ark_bn254::Fq::MODULUS.into();
+                let valid_fq = bigint::less_than_constant(circuit, pubinp, &q);
                 let new_wire = circuit.issue_wire();
                 circuit.add_gate(crate::Gate {
                     wire_a: and_all_wires,

--- a/g16ckt/src/gadgets/groth16.rs
+++ b/g16ckt/src/gadgets/groth16.rs
@@ -111,8 +111,7 @@ pub fn groth16_verify<C: CircuitContext>(
     Fq12::equal_constant(circuit, &f, &Fq12::as_montgomery(alpha_beta))
 }
 
-/// Convenience wrapper: verify using compressed A and C (x, y_flag). B remains host-provided `G2Affine`.
-/// Includes optimization for empty public inputs to avoid unnecessary MSM computation.
+/// Verify a 128-byte compressed serialized groth16 proof using public inputs
 pub fn groth16_verify_compressed<C: CircuitContext>(
     circuit: &mut C,
     input: &Groth16VerifyCompressedInputWires,
@@ -132,8 +131,8 @@ pub fn groth16_verify_compressed<C: CircuitContext>(
 
     let valid = circuit.issue_wire();
     circuit.add_gate(crate::Gate {
-        wire_a: verified_res,
-        wire_b: proof.valid,
+        wire_a: verified_res, // proof verification was successful
+        wire_b: proof.valid,  // input is valid
         wire_c: valid,
         gate_type: crate::GateType::And,
     });
@@ -272,6 +271,7 @@ pub struct Groth16VerifyCompressedInput {
     pub vk: VerifyingKey<Bn254>,
 }
 
+/// Compressed groth16 proof with public inputs
 #[derive(Debug)]
 pub struct Groth16VerifyCompressedInputWires {
     pub public: Vec<Fr>,
@@ -279,9 +279,12 @@ pub struct Groth16VerifyCompressedInputWires {
     pub vk: VerifyingKey<Bn254>,
 }
 
+/// Serialized 128 byte representation of groth16 proof in arkworks' serialized format
 #[derive(Debug, Clone, Copy)]
 pub struct SerializedCompressedProofWires(pub [WireId; 128 * 8]);
 
+/// Groth16 Proof elements `{a, b, c}` along with `valid` flag indicating whether the
+/// input (i.e. `SerializedCompressedProofWires`), from which this was obtained, was valid to begin with.
 #[derive(Debug, Clone)]
 pub struct DeserializedCompressedProofWires {
     a: G1Projective,

--- a/g16gen/src/passes/input_bits.rs
+++ b/g16gen/src/passes/input_bits.rs
@@ -4,13 +4,9 @@ use std::{
 };
 
 use g16ckt::{
-    Fq2Wire, WireId,
-    ark::{CurveGroup, Field},
+    WireId,
     circuit::CircuitInput,
-    gadgets::{
-        bn254::{fq::Fq, fr::Fr},
-        groth16::Groth16VerifyCompressedInput,
-    },
+    gadgets::{bigint::BigIntWires, groth16::Groth16VerifyCompressedInput},
 };
 
 const INPUT_BITS_FILE: &str = "inputs.txt";
@@ -28,8 +24,8 @@ pub fn write_input_bits(inputs: &Groth16VerifyCompressedInput) -> std::io::Resul
     let mut bits = Vec::with_capacity(wire_ids.len());
 
     // Extract public field element bits
-    for (wire_repr, value) in input_wires.public.iter().zip(inputs.0.public.iter()) {
-        let bits_fn = Fr::get_wire_bits_fn(wire_repr, value)
+    for (wire_repr, value) in input_wires.public.iter().zip(inputs.public.iter()) {
+        let bits_fn = BigIntWires::get_wire_bits_fn(wire_repr, value)
             .expect("Failed to get bits function for public input");
 
         for &wire_id in wire_repr.iter() {
@@ -39,59 +35,7 @@ pub fn write_input_bits(inputs: &Groth16VerifyCompressedInput) -> std::io::Resul
         }
     }
 
-    // Extract compressed point A (x-coordinate + y-flag)
-    let a_aff_std = inputs.0.a.into_affine();
-    let a_x_m = Fq::as_montgomery(a_aff_std.x);
-    let a_flag = (a_aff_std.y.square())
-        .sqrt()
-        .expect("y^2 must be QR")
-        .eq(&a_aff_std.y);
-
-    let a_x_fn = Fq::get_wire_bits_fn(&input_wires.a.x_m, &a_x_m)
-        .expect("Failed to get bits function for point A x-coordinate");
-
-    for &wire_id in input_wires.a.x_m.iter() {
-        if let Some(bit) = a_x_fn(wire_id) {
-            bits.push(bit);
-        }
-    }
-    bits.push(a_flag);
-
-    // Extract compressed point B (x-coordinate + y-flag)
-    let b_aff_std = inputs.0.b.into_affine();
-    let b_x_m = Fq2Wire::as_montgomery(b_aff_std.x);
-    let b_flag = (b_aff_std.y.square())
-        .sqrt()
-        .expect("y^2 must be QR in Fq2")
-        .eq(&b_aff_std.y);
-
-    let b_x_fn = Fq2Wire::get_wire_bits_fn(&input_wires.b.p, &b_x_m)
-        .expect("Failed to get bits function for point B x-coordinate");
-
-    for &wire_id in input_wires.b.p.iter() {
-        if let Some(bit) = b_x_fn(wire_id) {
-            bits.push(bit);
-        }
-    }
-    bits.push(b_flag);
-
-    // Extract compressed point C (x-coordinate + y-flag)
-    let c_aff_std = inputs.0.c.into_affine();
-    let c_x_m = Fq::as_montgomery(c_aff_std.x);
-    let c_flag = (c_aff_std.y.square())
-        .sqrt()
-        .expect("y^2 must be QR")
-        .eq(&c_aff_std.y);
-
-    let c_x_fn = Fq::get_wire_bits_fn(&input_wires.c.x_m, &c_x_m)
-        .expect("Failed to get bits function for point C x-coordinate");
-
-    for &wire_id in input_wires.c.x_m.iter() {
-        if let Some(bit) = c_x_fn(wire_id) {
-            bits.push(bit);
-        }
-    }
-    bits.push(c_flag);
+    bits.extend_from_slice(&inputs.proof);
 
     // Verify we extracted the expected number of bits
     assert_eq!(


### PR DESCRIPTION
Fixes #56 

Merges changes in PR #42 and #9 so that all validation wires are tied.
