### PR TITLE
feat(g16gen): represent fanout_ctr with u32

### DIFF
--- a/g16gen/src/cache.rs
+++ b/g16gen/src/cache.rs
@@ -9,24 +9,24 @@ const FANOUT_FILE: &str = "fanout.cache";
 const OUTPUT_WIRES_FILE: &str = "outputs.cache";
 
 /// Try to load cached fanout and output wires from files
-pub fn try_load_cache() -> Option<(Vec<u16>, Vec<WireId>)> {
+pub fn try_load_cache() -> Option<(Vec<u32>, Vec<WireId>)> {
     let fanout = load_fanout()?;
     let output_wires = load_output_wires()?;
     Some((fanout, output_wires))
 }
 
 /// Load fanout from cache file
-fn load_fanout() -> Option<Vec<u16>> {
+fn load_fanout() -> Option<Vec<u32>> {
     let file = OpenOptions::new().read(true).open(FANOUT_FILE).ok()?;
     let mut reader = BufReader::new(file);
     let mut fanout = Vec::new();
 
     loop {
-        let mut buf = [0u8; 2];
+        let mut buf = [0u8; 4];
         if reader.read_exact(&mut buf).is_err() {
             break;
         }
-        fanout.push(u16::from_le_bytes(buf));
+        fanout.push(u32::from_le_bytes(buf));
     }
 
     Some(fanout)
@@ -50,7 +50,7 @@ fn load_output_wires() -> Option<Vec<WireId>> {
 }
 
 /// Save fanout to cache file
-pub fn save_fanout(fanout: &[u16]) -> std::io::Result<()> {
+pub fn save_fanout(fanout: &[u32]) -> std::io::Result<()> {
     let file = OpenOptions::new()
         .write(true)
         .create(true)
@@ -82,7 +82,7 @@ pub fn save_output_wires(output_wires: &[WireId]) -> std::io::Result<()> {
 }
 
 /// Save both credits and output wires to cache files
-pub fn save_cache(credits: &[u16], output_wires: &[WireId]) -> std::io::Result<()> {
+pub fn save_cache(credits: &[u32], output_wires: &[WireId]) -> std::io::Result<()> {
     save_fanout(credits)?;
     save_output_wires(output_wires)?;
     Ok(())

--- a/g16gen/src/modes/fanout_ctr.rs
+++ b/g16gen/src/modes/fanout_ctr.rs
@@ -7,7 +7,7 @@ use indicatif::ProgressBar;
 
 #[derive(Debug)]
 pub struct FanoutCounter {
-    fanout: Option<Vec<u16>>, // Original -> Normalized IDs
+    fanout: Option<Vec<u32>>, // Original -> Normalized IDs
     next_normalized_id: u64,
     primary_inputs: usize,
     biggest_fanout_seen: usize,
@@ -43,7 +43,7 @@ impl CircuitMode for FanoutCounter {
     fn evaluate_gate(&mut self, gate: &SourceGate) {
         self.spinner.inc(1);
 
-        let resize = |fanout: &mut Vec<u16>, max_wire_produced: usize| {
+        let resize = |fanout: &mut Vec<u32>, max_wire_produced: usize| {
             if max_wire_produced >= fanout.len() {
                 fanout.resize(max_wire_produced + 1, 0);
             }
@@ -188,18 +188,23 @@ impl FanoutCounter {
         id
     }
 
-    fn wire_used(&mut self, wire_id: WireId) -> u16 {
+    // fn top_n(mut v: Vec<u16>, n: usize) -> Vec<u16> {
+    //     v.sort_unstable_by(|a, b| b.cmp(a)); // descending
+    //     v.truncate(n);
+    //     v
+    // }
+
+    fn wire_used(&mut self, wire_id: WireId) -> u32 {
         let wire_id = wire_id.0;
         if (0..self.primary_inputs + 2).contains(&wire_id) {
             return 0;
         }
         let fanout = self.fanout.as_mut().unwrap();
-
         fanout[wire_id] += 1;
         fanout[wire_id]
     }
 
-    pub fn finish(&mut self) -> (Vec<u16>, usize) {
+    pub fn finish(&mut self) -> (Vec<u32>, usize) {
         let fanout = self.fanout.take().unwrap();
         (fanout, self.biggest_fanout_seen)
     }

--- a/g16gen/src/modes/fanout_ctr.rs
+++ b/g16gen/src/modes/fanout_ctr.rs
@@ -188,12 +188,6 @@ impl FanoutCounter {
         id
     }
 
-    // fn top_n(mut v: Vec<u16>, n: usize) -> Vec<u16> {
-    //     v.sort_unstable_by(|a, b| b.cmp(a)); // descending
-    //     v.truncate(n);
-    //     v
-    // }
-
     fn wire_used(&mut self, wire_id: WireId) -> u32 {
         let wire_id = wire_id.0;
         if (0..self.primary_inputs + 2).contains(&wire_id) {

--- a/g16gen/src/modes/translate.rs
+++ b/g16gen/src/modes/translate.rs
@@ -18,7 +18,7 @@ use kanal::{Sender, bounded_async};
 use monoio::{FusionDriver, RuntimeBuilder, select};
 
 pub struct TranslationMode {
-    creds: Vec<u16>,
+    creds: Vec<u32>,
     next_normalized_id: u64,
 
     // Constants
@@ -72,7 +72,7 @@ impl CircuitMode for TranslationMode {
 
 impl TranslationMode {
     pub async fn new(
-        creds: Vec<u16>,
+        creds: Vec<u32>,
         path: &str,
         primary_inputs: u64,
         outputs: Vec<WireId>,
@@ -151,7 +151,7 @@ impl TranslationMode {
             in1: in1.to_u64(),
             in2: in2.to_u64(),
             out: out.to_u64(),
-            credits: self.creds[out.to_u64() as usize] as u32,
+            credits: self.creds[out.to_u64() as usize],
             gate_type,
         };
         loop {

--- a/g16gen/src/passes/credits.rs
+++ b/g16gen/src/passes/credits.rs
@@ -14,7 +14,7 @@ use crate::modes::fanout_ctr::FanoutCounter;
 pub fn run_credits_pass(
     inputs: &Groth16VerifyCompressedInput,
     primary_input_count: usize,
-) -> (Vec<u16>, Vec<WireId>) {
+) -> (Vec<u32>, Vec<WireId>) {
     let (allocated_inputs, root_meta) = ComponentMetaBuilder::new_with_input(inputs);
     let mut metadata_mode = StreamingMode::<FanoutCounter>::MetadataPass(root_meta);
 

--- a/g16gen/src/passes/translation.rs
+++ b/g16gen/src/passes/translation.rs
@@ -16,7 +16,7 @@ const OUTPUT_FILE: &str = "g16.ckt";
 pub async fn run_translation_pass(
     inputs: &Groth16VerifyCompressedInput,
     primary_input_count: usize,
-    credits: Vec<u16>,
+    credits: Vec<u32>,
     output_wires: Vec<WireId>,
 ) {
     let (allocated_inputs, root_meta) = ComponentMetaBuilder::new_with_input(inputs);


### PR DESCRIPTION
Represent fanout_ctr with u32 because u16 doesn't suffice after audit fixes. 
Max value attained by fanout_ctr is around u21::MAX