### PR TITLE
test: fix random number generation in tests

### DIFF
--- a/g16ckt/examples/pairing_gate_counts.rs
+++ b/g16ckt/examples/pairing_gate_counts.rs
@@ -16,8 +16,6 @@ use g16ckt::{
 use gsv::gadgets::bn254::{
     fq::Fq, fq2::Fq2, fq12::Fq12, g1::G1Projective, g2::G2Projective, pairing,
 };
-use rand::SeedableRng;
-use rand_chacha::ChaCha20Rng;
 
 fn fq12_one_const() -> Fq12 {
     Fq12::new_constant(ark::Fq12::ONE)
@@ -100,7 +98,6 @@ fn main() {
     const ENABLE_DESERIALIZED_COMPRESSED_G2: bool = true;
 
     // Deterministic inputs - use affine points with z=1 for fair comparison
-    let _rng = ChaCha20Rng::seed_from_u64(42);
     let g1_proj = ark::G1Projective::generator() * ark::Fr::from(5u64);
     let g2_proj = ark::G2Projective::generator() * ark::Fr::from(7u64);
     // Convert to affine then back to projective with z=1

--- a/g16ckt/src/core/s.rs
+++ b/g16ckt/src/core/s.rs
@@ -131,12 +131,12 @@ impl BitXorAssign<&S> for S {
 
 #[cfg(test)]
 mod tests {
-    use rand::SeedableRng;
+    use rand::{SeedableRng, rngs::OsRng};
 
     use super::*;
 
     fn rnd() -> S {
-        S::random(&mut rand::rngs::StdRng::from_seed([0u8; 32]))
+        S::random(&mut OsRng)
     }
 
     #[test]

--- a/g16ckt/src/gadgets/basic.rs
+++ b/g16ckt/src/gadgets/basic.rs
@@ -106,10 +106,11 @@ pub fn multiplexer<C: CircuitContext>(
 
 #[cfg(test)]
 mod tests {
+    use rand::rngs::OsRng;
     use test_log::test;
 
     use super::*;
-    use crate::{circuit::CircuitBuilder, test_utils::trng};
+    use crate::circuit::CircuitBuilder;
 
     #[test]
     fn not_not() {
@@ -324,7 +325,7 @@ mod tests {
 
         use crate::circuit::{CircuitInput, EncodeInput, modes::CircuitMode};
 
-        let mut rng = trng();
+        let mut rng = OsRng;
 
         // Test with w=3, which means 8 inputs and 3 selector bits
         // Ad-hoc structure for this test

--- a/g16ckt/src/gadgets/bn254/fq.rs
+++ b/g16ckt/src/gadgets/bn254/fq.rs
@@ -317,7 +317,7 @@ pub(super) mod tests {
     use std::{array, iter};
 
     use ark_ff::AdditiveGroup;
-    use rand::{Rng, SeedableRng};
+    use rand::{Rng, SeedableRng, rngs::OsRng};
     use rand_chacha::ChaCha20Rng;
     use test_log::test;
     use tracing::trace;
@@ -332,7 +332,6 @@ pub(super) mod tests {
             bigint::{BigUint as BigUintOutput, bits_from_biguint_with_len},
             bn254::fp254impl::Fp254Impl,
         },
-        test_utils::trng,
     };
 
     // Input struct for Fq tests
@@ -392,14 +391,14 @@ pub(super) mod tests {
 
     pub fn rnd() -> ark_bn254::Fq {
         loop {
-            if let Some(bn) = ark_bn254::Fq::from_random_bytes(&trng().r#gen::<[u8; 32]>()) {
+            if let Some(bn) = ark_bn254::Fq::from_random_bytes(&OsRng.r#gen::<[u8; 32]>()) {
                 return bn;
             }
         }
     }
 
     fn random() -> ark_bn254::Fq {
-        Fq::random(&mut trng())
+        Fq::random(&mut OsRng)
     }
 
     #[test]
@@ -722,7 +721,7 @@ pub(super) mod tests {
         let w = 1;
         let n = 2_usize.pow(w as u32);
         let a_val = (0..n).map(|_| random()).collect::<Vec<_>>();
-        let s_val = (0..w).map(|_| trng().r#gen()).collect::<Vec<_>>();
+        let s_val = (0..w).map(|_| OsRng.r#gen()).collect::<Vec<_>>();
 
         let mut u = 0;
         for i in s_val.iter().rev() {

--- a/g16ckt/src/gadgets/bn254/fq12.rs
+++ b/g16ckt/src/gadgets/bn254/fq12.rs
@@ -502,6 +502,7 @@ mod tests {
 
     use ark_ff::{CyclotomicMultSubgroup, PrimeField};
     use num_bigint::BigUint;
+    use rand::rngs::OsRng;
     use test_log::test;
 
     use super::*;
@@ -514,11 +515,10 @@ mod tests {
             bigint::{BigUint as BigUintOutput, bits_from_biguint_with_len},
             bn254::{Fp254Impl, fq::Fq},
         },
-        test_utils::trng,
     };
 
     fn random() -> ark_bn254::Fq12 {
-        Fq12::random(&mut trng())
+        Fq12::random(&mut OsRng)
     }
 
     // Input struct for Fq12 tests
@@ -766,8 +766,8 @@ mod tests {
     #[test]
     fn test_fq12_mul_by_34_montgomery() {
         let a = random();
-        let c3 = Fq2::random(&mut trng());
-        let c4 = Fq2::random(&mut trng());
+        let c3 = Fq2::random(&mut OsRng);
+        let c4 = Fq2::random(&mut OsRng);
 
         // Custom input type for this complex test
         struct MulBy34Input {
@@ -867,9 +867,9 @@ mod tests {
     #[test]
     fn test_fq12_mul_by_034_montgomery() {
         let a = random();
-        let c0 = Fq2::random(&mut trng());
-        let c3 = Fq2::random(&mut trng());
-        let c4 = Fq2::random(&mut trng());
+        let c0 = Fq2::random(&mut OsRng);
+        let c3 = Fq2::random(&mut OsRng);
+        let c4 = Fq2::random(&mut OsRng);
 
         // Custom input type for this complex test
         struct MulBy034Input {
@@ -956,10 +956,9 @@ mod tests {
     #[test]
     fn test_fq12_mul_by_034_constant4_montgomery() {
         let a = random();
-        let mut rng = trng();
-        let c0 = Fq2::random(&mut rng);
-        let c3 = Fq2::random(&mut rng);
-        let c4 = Fq2::random(&mut rng);
+        let c0 = Fq2::random(&mut OsRng);
+        let c3 = Fq2::random(&mut OsRng);
+        let c4 = Fq2::random(&mut OsRng);
 
         // Custom input type for this test (c0, c3 are wires, c4 is constant)
         struct MulBy034Const4Input {
@@ -1062,7 +1061,7 @@ mod tests {
         let p = Fq::modulus_as_biguint();
         let u = (p.pow(6) - BigUint::from_str("1").unwrap())
             * (p.pow(2) + BigUint::from_str("1").unwrap());
-        let a = Fq12::random(&mut trng()).pow(u.to_u64_digits());
+        let a = Fq12::random(&mut OsRng).pow(u.to_u64_digits());
         let a_m = Fq12::as_montgomery(a);
         let mut expected_a = a;
         expected_a.cyclotomic_square_in_place();

--- a/g16ckt/src/gadgets/bn254/fq2.rs
+++ b/g16ckt/src/gadgets/bn254/fq2.rs
@@ -464,6 +464,7 @@ mod tests {
     use std::array;
 
     use ark_ff::{AdditiveGroup, Fp6Config, PrimeField};
+    use rand::rngs::OsRng;
     use test_log::test;
 
     use super::*;
@@ -476,11 +477,10 @@ mod tests {
             bigint::{BigUint as BigUintOutput, bits_from_biguint_with_len},
             bn254::fp254impl::Fp254Impl,
         },
-        test_utils::trng,
     };
 
     fn random() -> ark_bn254::Fq2 {
-        Fq2::random(&mut trng())
+        Fq2::random(&mut OsRng)
     }
 
     #[test]

--- a/g16ckt/src/gadgets/bn254/fq6.rs
+++ b/g16ckt/src/gadgets/bn254/fq6.rs
@@ -530,6 +530,7 @@ impl Fq6 {
 #[cfg(test)]
 mod tests {
     use ark_ff::{AdditiveGroup, Field, Fp12Config, PrimeField};
+    use rand::rngs::OsRng;
     use test_log::test;
 
     use super::*;
@@ -542,11 +543,10 @@ mod tests {
             bigint::{BigUint as BigUintOutput, bits_from_biguint_with_len},
             bn254::fp254impl::Fp254Impl,
         },
-        test_utils::trng,
     };
 
     fn random() -> ark_bn254::Fq6 {
-        Fq6::random(&mut trng())
+        Fq6::random(&mut OsRng)
     }
 
     // Input struct for Fq6 tests
@@ -915,7 +915,7 @@ mod tests {
         }
 
         let a = random();
-        let b = crate::gadgets::bn254::fq2::Fq2::random(&mut trng());
+        let b = crate::gadgets::bn254::fq2::Fq2::random(&mut OsRng);
         let expected = Fq6::as_montgomery(
             a * ark_bn254::Fq6::new(b, ark_bn254::Fq2::ZERO, ark_bn254::Fq2::ZERO),
         );
@@ -931,7 +931,7 @@ mod tests {
     #[test]
     fn test_fq6_mul_by_constant_fq2_montgomery() {
         let a = random();
-        let b = crate::gadgets::bn254::fq2::Fq2::random(&mut trng());
+        let b = crate::gadgets::bn254::fq2::Fq2::random(&mut OsRng);
         let expected = Fq6::as_montgomery(
             a * ark_bn254::Fq6::new(b, ark_bn254::Fq2::ZERO, ark_bn254::Fq2::ZERO),
         );
@@ -1132,8 +1132,8 @@ mod tests {
         }
 
         let a = random();
-        let c0 = crate::gadgets::bn254::fq2::Fq2::random(&mut trng());
-        let c1 = crate::gadgets::bn254::fq2::Fq2::random(&mut trng());
+        let c0 = crate::gadgets::bn254::fq2::Fq2::random(&mut OsRng);
+        let c1 = crate::gadgets::bn254::fq2::Fq2::random(&mut OsRng);
         let mut expected = a;
         expected.mul_by_01(&c0, &c1);
         let expected = Fq6::as_montgomery(expected);
@@ -1265,8 +1265,8 @@ mod tests {
         }
 
         let a = random();
-        let c0 = crate::gadgets::bn254::fq2::Fq2::random(&mut trng());
-        let c1 = crate::gadgets::bn254::fq2::Fq2::random(&mut trng());
+        let c0 = crate::gadgets::bn254::fq2::Fq2::random(&mut OsRng);
+        let c1 = crate::gadgets::bn254::fq2::Fq2::random(&mut OsRng);
         let mut expected = a;
         expected.mul_by_01(&c0, &c1);
         let expected = Fq6::as_montgomery(expected);

--- a/g16ckt/src/gadgets/bn254/fr.rs
+++ b/g16ckt/src/gadgets/bn254/fr.rs
@@ -139,14 +139,13 @@ impl Fr {
 #[cfg(test)]
 mod tests {
     use ark_ff::Field;
-    use rand::Rng;
+    use rand::{Rng, rngs::OsRng};
 
     use super::*;
-    use crate::test_utils::trng;
 
     fn rnd() -> ark_bn254::Fr {
         loop {
-            if let Some(bn) = ark_bn254::Fr::from_random_bytes(&trng().r#gen::<[u8; 32]>()) {
+            if let Some(bn) = ark_bn254::Fr::from_random_bytes(&OsRng.r#gen::<[u8; 32]>()) {
                 return bn;
             }
         }

--- a/g16ckt/src/gadgets/bn254/g1.rs
+++ b/g16ckt/src/gadgets/bn254/g1.rs
@@ -661,14 +661,11 @@ mod tests {
     use ark_ec::{CurveGroup, PrimeGroup, VariableBaseMSM};
     use ark_ff::UniformRand;
     use ark_serialize::CanonicalSerialize;
-    use rand::{Rng, SeedableRng, thread_rng};
+    use rand::{Rng, SeedableRng, rngs::OsRng};
     use rand_chacha::ChaCha20Rng;
 
     use super::*;
-    use crate::{
-        circuit::{CircuitBuilder, CircuitInput, EncodeInput, modes::CircuitMode},
-        test_utils::trng,
-    };
+    use crate::circuit::{CircuitBuilder, CircuitInput, EncodeInput, modes::CircuitMode};
 
     pub fn rnd_fr(rng: &mut impl Rng) -> ark_bn254::Fr {
         let mut prng = ChaCha20Rng::seed_from_u64(rng.r#gen());
@@ -727,7 +724,7 @@ mod tests {
     #[test]
     fn test_g1p_add_montgomery() {
         // Generate random G1 points
-        let mut rng = thread_rng();
+        let mut rng = OsRng;
         let a = rnd_g1(&mut rng);
         let b = rnd_g1(&mut rng);
         let c = a + b;
@@ -816,7 +813,7 @@ mod tests {
     #[test]
     fn test_g1p_double_montgomery() {
         // Generate random G1 points
-        let mut rng = thread_rng();
+        let mut rng = OsRng;
         let a = rnd_g1(&mut rng);
         let c = a + a;
 
@@ -883,9 +880,9 @@ mod tests {
         let w = 2;
         let n = 2_usize.pow(w as u32);
         let a_val = (0..n)
-            .map(|_| G1Projective::as_montgomery(rnd_g1(&mut trng())))
+            .map(|_| G1Projective::as_montgomery(rnd_g1(&mut OsRng)))
             .collect::<Vec<_>>();
-        let s_val = (0..w).map(|_| trng().r#gen()).collect::<Vec<_>>();
+        let s_val = (0..w).map(|_| OsRng.r#gen()).collect::<Vec<_>>();
 
         let mut u = 0;
         for i in s_val.iter().rev() {
@@ -962,8 +959,8 @@ mod tests {
 
     #[test]
     fn test_g1p_scalar_mul_with_constant_base_montgomery() {
-        let s = rnd_fr(&mut trng());
-        let p = rnd_g1(&mut trng());
+        let s = rnd_fr(&mut OsRng);
+        let p = rnd_g1(&mut OsRng);
         let result = p * s;
 
         // Define input structure
@@ -1015,8 +1012,8 @@ mod tests {
     #[test]
     fn test_msm_with_constant_bases_montgomery() {
         let n = 1;
-        let scalars = (0..n).map(|_| rnd_fr(&mut trng())).collect::<Vec<_>>();
-        let bases = (0..n).map(|_| rnd_g1(&mut trng())).collect::<Vec<_>>();
+        let scalars = (0..n).map(|_| rnd_fr(&mut OsRng)).collect::<Vec<_>>();
+        let bases = (0..n).map(|_| rnd_g1(&mut OsRng)).collect::<Vec<_>>();
         let bases_affine = bases.iter().map(|g| g.into_affine()).collect::<Vec<_>>();
         let result = ark_bn254::G1Projective::msm(&bases_affine, &scalars).unwrap();
 
@@ -1078,7 +1075,7 @@ mod tests {
     #[test]
     fn test_g1p_neg() {
         // Generate random G1 point
-        let a = rnd_g1(&mut trng());
+        let a = rnd_g1(&mut OsRng);
         let neg_a = -a;
 
         // Convert to Montgomery form

--- a/g16ckt/src/gadgets/bn254/g2.rs
+++ b/g16ckt/src/gadgets/bn254/g2.rs
@@ -790,14 +790,13 @@ mod tests {
     use ark_ec::{AffineRepr, CurveGroup, PrimeGroup};
     use ark_ff::UniformRand;
     use ark_serialize::CanonicalSerialize;
-    use rand::{Rng, SeedableRng, thread_rng};
+    use rand::{Rng, SeedableRng, rngs::OsRng};
     use rand_chacha::ChaCha20Rng;
 
     use super::*;
     use crate::{
         circuit::{CircuitBuilder, CircuitInput, EncodeInput, modes::CircuitMode},
         gadgets::bn254::pairing::double_in_place,
-        test_utils::trng,
     };
 
     pub fn rnd_g2(rng: &mut impl Rng) -> ark_bn254::G2Projective {
@@ -856,7 +855,7 @@ mod tests {
     #[test]
     fn test_g2p_add_montgomery() {
         // Generate random G2 points
-        let mut rng = thread_rng();
+        let mut rng = OsRng;
         let a = rnd_g2(&mut rng);
         let b = rnd_g2(&mut rng);
         let c = a + b;
@@ -886,7 +885,7 @@ mod tests {
     #[test]
     fn test_g2p_double_montgomery() {
         // Generate random G2 point
-        let mut rng = thread_rng();
+        let mut rng = OsRng;
         let a = rnd_g2(&mut rng);
         let c = a + a;
 
@@ -910,7 +909,7 @@ mod tests {
         use ark_ec::CurveGroup;
 
         // a is in Jacobian
-        let mut rng = thread_rng();
+        let mut rng = OsRng;
         let a = rnd_g2(&mut rng);
 
         // Jacobian doubling via library, then to affine
@@ -934,7 +933,7 @@ mod tests {
     #[test]
     fn test_g2p_neg() {
         // Generate random G2 point
-        let a = rnd_g2(&mut trng());
+        let a = rnd_g2(&mut OsRng);
         let neg_a = -a;
 
         // Convert to Montgomery form
@@ -957,9 +956,9 @@ mod tests {
         let w = 2;
         let n = 2_usize.pow(w as u32);
         let a_val = (0..n)
-            .map(|_| G2Projective::as_montgomery(rnd_g2(&mut trng())))
+            .map(|_| G2Projective::as_montgomery(rnd_g2(&mut OsRng)))
             .collect::<Vec<_>>();
-        let s_val = (0..w).map(|_| trng().r#gen()).collect::<Vec<_>>();
+        let s_val = (0..w).map(|_| OsRng.r#gen()).collect::<Vec<_>>();
 
         let mut u = 0;
         for i in s_val.iter().rev() {

--- a/g16ckt/src/lib.rs
+++ b/g16ckt/src/lib.rs
@@ -23,16 +23,6 @@ pub use gadgets::{
 pub use logging::init_tracing;
 pub use math::*;
 
-#[cfg(test)]
-pub mod test_utils {
-    use rand::SeedableRng;
-    use rand_chacha::ChaCha20Rng;
-
-    pub fn trng() -> ChaCha20Rng {
-        ChaCha20Rng::seed_from_u64(0)
-    }
-}
-
 // All ark-* related items live under this module for clarity
 pub mod ark {
     // Field traits and RNG utilities

--- a/pipeline/src/main.rs
+++ b/pipeline/src/main.rs
@@ -11,9 +11,8 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
-use tracing::{error, info};
-
 use run_dir::{RunDir, StepTiming, cleanup_intermediates, update_latest_symlink, write_summary};
+use tracing::{error, info};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]


### PR DESCRIPTION
Several deterministic random number generators used in testing were called in ways that unexpectedly produced identical values within tests, rendering the validity of those tests questionable or moot.

While it's possible to fix this while still using deterministic generators, this would require more significant and annoying refactoring. Instead, this PR fixes the problem by using high-entropy `OsRng` calls.

Closes #62.