### PR TITLE
fix:add command to verify proof over existing circuit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 fanout.cache
 outputs.cache
 *.ckt
+/pipeline-runs
+/validation-runs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,8 +542,32 @@ dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
  "pairing",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -601,6 +625,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,7 +664,7 @@ dependencies = [
 [[package]]
 name = "ckt-fmtv5-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/ckt#88c8701066787edd770acd76f928dcdf12071645"
+source = "git+https://github.com/alpenlabs/ckt#86183dbd3f4c24cf441c294835b3133d739382af"
 dependencies = [
  "blake3",
  "cynosure 0.4.0",
@@ -644,9 +674,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckt-gobble"
+version = "0.1.0"
+source = "git+https://github.com/alpenlabs/ckt#86183dbd3f4c24cf441c294835b3133d739382af"
+dependencies = [
+ "bitvec",
+ "blake3",
+ "rand_chacha 0.10.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ckt-lvl"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/ckt#88c8701066787edd770acd76f928dcdf12071645"
+source = "git+https://github.com/alpenlabs/ckt#86183dbd3f4c24cf441c294835b3133d739382af"
 dependencies = [
  "ahash",
  "ckt-fmtv5-types",
@@ -655,6 +696,27 @@ dependencies = [
  "mimalloc",
  "monoio",
  "roaring",
+]
+
+[[package]]
+name = "ckt-runner-exec"
+version = "0.1.0"
+source = "git+https://github.com/alpenlabs/ckt#86183dbd3f4c24cf441c294835b3133d739382af"
+dependencies = [
+ "anyhow",
+ "bitvec",
+ "blake3",
+ "ckt-fmtv5-types",
+ "ckt-gobble",
+ "ckt-runner-types",
+]
+
+[[package]]
+name = "ckt-runner-types"
+version = "0.1.0"
+source = "git+https://github.com/alpenlabs/ckt#86183dbd3f4c24cf441c294835b3133d739382af"
+dependencies = [
+ "ckt-fmtv5-types",
 ]
 
 [[package]]
@@ -1006,7 +1068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "bitvec",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1019,7 +1081,7 @@ dependencies = [
  "bitvec",
  "byteorder",
  "ff_derive",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1177,16 +1239,21 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ark-serialize 0.5.0",
+ "bincode",
  "chrono",
  "ckt-fmtv5-types",
  "ckt-lvl",
  "clap",
+ "gobbletest",
+ "hex",
  "monoio",
  "num-bigint 0.4.6",
+ "serde",
  "serde_json",
  "sp1-verifier",
  "tracing",
  "tracing-subscriber 0.3.23",
+ "zkaleido-sp1-groth16-verifier",
 ]
 
 [[package]]
@@ -1223,7 +1290,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "rand",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rayon",
  "serde",
  "serde_json",
@@ -1250,7 +1317,7 @@ dependencies = [
  "kanal",
  "monoio",
  "rand",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "serde",
  "serde_json",
  "tracing",
@@ -1317,6 +1384,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gobbletest"
+version = "0.1.0"
+source = "git+https://github.com/alpenlabs/ckt#86183dbd3f4c24cf441c294835b3133d739382af"
+dependencies = [
+ "bitvec",
+ "ckt-fmtv5-types",
+ "ckt-gobble",
+ "ckt-runner-exec",
+ "ckt-runner-types",
+ "indicatif",
+ "monoio",
+ "rand_chacha 0.10.0",
+]
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,7 +1406,7 @@ checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff 0.12.1",
  "memuse",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1335,7 +1417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff 0.13.1",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1358,7 +1440,7 @@ dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
  "pasta_curves 0.4.1",
- "rand_core",
+ "rand_core 0.6.4",
  "rayon",
 ]
 
@@ -1551,7 +1633,7 @@ dependencies = [
  "bls12_381",
  "ff 0.12.1",
  "group 0.12.1",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1661,7 +1743,7 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core",
+ "rand_core 0.6.4",
  "zeroize",
 ]
 
@@ -2184,6 +2266,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,8 +2311,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2231,7 +2322,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2242,6 +2343,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "range-set-blaze"
@@ -3035,9 +3142,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.2.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c2ee159035d43b7d268178c28e8a2b9433088a55434da2a57be89ef33e77195"
+checksum = "f97f6c90e5f44ffaa18e0cf7aab2f4f02d0a2261aee21d4a48e09cc453ef0e0e"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3131,6 +3238,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -3324,6 +3444,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -3812,6 +3944,9 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -3866,6 +4001,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zkaleido"
+version = "0.1.0"
+source = "git+https://github.com/alpenlabs/zkaleido#e8a18213448fffeb3f829c61e2f6590c5aa94b22"
+dependencies = [
+ "bincode",
+ "borsh",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "zkaleido-sp1-groth16-verifier"
+version = "0.1.0"
+source = "git+https://github.com/alpenlabs/zkaleido#e8a18213448fffeb3f829c61e2f6590c5aa94b22"
+dependencies = [
+ "blake3",
+ "sha2",
+ "substrate-bn",
+ "thiserror 2.0.18",
+ "zkaleido",
 ]
 
 [[package]]

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -8,17 +8,23 @@ name = "g16-pipeline"
 path = "src/main.rs"
 
 [dependencies]
-sp1-verifier = { version = "=6.2.0", features = ["ark"] }
+zkaleido-sp1-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", default-features = false }
 
 ckt-fmtv5-types = { git = "https://github.com/alpenlabs/ckt", features = ["v5"] }
 ckt-lvl = { git = "https://github.com/alpenlabs/ckt" }
+gobbletest = { git = "https://github.com/alpenlabs/ckt" }
+
+sp1-verifier = { version = "=6.1.0", features = ["ark"] }
 
 ark-serialize = "0.5.0"
 
 num-bigint = "0.4"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+bincode = "1"
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
+hex = "0.4"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 monoio = { version = "0.2.4", features = ["sync"] }

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -1,14 +1,9 @@
 # g16-pipeline
 
-Generates a v5c boolean circuit (`v5c.ckt`) for the SP1 Groth16 verifier of a specific program, given the program's 32-byte vkey hash.
+Generates and validates v5c boolean circuits (`v5c.ckt`) for the SP1 Groth16 verifier of a specific program.
 
-The pipeline does, in order:
-
-1. Synthesize `compile_time.json` from the vkey hash + SP1 v6 standard constants.
-2. `g16gen generate` → v5a circuit (subprocess).
-3. `ckt-lvl::prealloc` → v5c circuit (in-process lib call).
-
-The resulting v5c is unvalidated by this tool — exercising it against a real proof is the responsibility of the downstream consumer.
+- **`gen --vkey`** — synthesize a v5c from the 32-byte vkey hash + SP1 v6 constants. No proof needed; the result is unvalidated.
+- **`validate-proof`** — sanity-check an existing v5c against a raw SP1 v6 prover artifact (bincode `SP1ProofWithPublicValues`, what `proof.save(...)` writes). Skips circuit generation.
 
 ## Usage
 
@@ -16,27 +11,24 @@ From the `g16/` workspace:
 
 ```sh
 cargo run -p g16-pipeline --release -- gen --vkey /path/to/vk.bin
+cargo run -p g16-pipeline --release -- validate-proof --v5c <v5c> --proof <sp1-artifact>
 ```
 
-Outputs land in `./pipeline-runs/run-YYYYMMDD-HHMMSS/`. A `pipeline-runs/latest` symlink (unix) points to the most recent successful run.
+`gen` writes to `pipeline-runs/run-YYYYMMDD-HHMMSS/`; `validate-proof` writes to `validation-runs/run-YYYYMMDD-HHMMSS/`. Each parent maintains its own `latest` symlink (unix). Override the parent with `--runs-dir` or env (`G16_PIPELINE_RUNS`, `G16_VALIDATION_RUNS`).
 
-### Flags
-
-| Flag                  | Default         | Notes                                                                                     |
-| --------------------- | --------------- | ----------------------------------------------------------------------------------------- |
-| `--vkey <path>`       | required        | Binary file containing the 32-byte SP1 program vkey hash (raw output of `bytes32_raw()`). |
-| `--runs-dir <path>`   | `pipeline-runs` | Parent directory for run folders. Env: `G16_PIPELINE_RUNS`.                               |
-| `--keep-intermediate` | off             | Keep `g16.ckt` (large v5a). Other files are kept regardless.                              |
+`gen` also takes `--keep-intermediate` (preserve `g16.ckt`, the large v5a).
 
 ### Run directory layout
 
 ```
-pipeline-runs/run-20260513-152412/
-├── v5c.ckt              ← the deliverable
-├── compile_time.json
-├── g16.ckt              ← deleted on success unless --keep-intermediate
-└── summary.txt          ← per-step durations
+pipeline-runs/run-…/      validation-runs/run-…/
+├── v5c.ckt               ├── run_time.json
+├── compile_time.json     ├── inputs.txt
+├── g16.ckt †             └── summary.txt
+└── summary.txt
 ```
+
+† deleted on success unless `--keep-intermediate`.
 
 On failure: nothing is cleaned, `latest` is not updated.
 
@@ -44,7 +36,7 @@ On failure: nothing is cleaned, `latest` is not updated.
 
 ## Requirements on the SP1 program
 
-These are properties of the verifier circuit (baked in by `g16gen`), not of the pipeline. The pipeline does not check them; the constraints surface downstream when proofs are run against the resulting circuit.
+These are properties of the verifier circuit (baked in by `g16gen`).
 
 ### `sp1-zkvm` must be built with the `blake3` feature
 
@@ -57,22 +49,24 @@ Enable the feature in the **SP1 program's** `Cargo.toml` (the guest, not the hos
 sp1-zkvm = { ..., features = ["blake3"] }
 ```
 
-This is a feature on `sp1-zkvm` (the guest entrypoint). At guest init it sets `PUBLIC_VALUES_HASHER = blake3::Hasher::new()` instead of `Sha256::new()` (`sp1-zkvm/src/lib.rs`).
-
 ### `public_values` must be exactly 36 bytes
 
-`g16gen` hard-codes `INPUT_MESSAGE_LEN = 36` (`g16gen/src/circuit_args.rs`). Programs committing a different number of bytes need a g16gen change to parameterize the input length, or the circuit they produce will not match the proof shape.
+`g16gen` hard-codes `INPUT_MESSAGE_LEN = 36` (`g16gen/src/circuit_args.rs`). `validate-proof` fails fast on a length mismatch; `gen --vkey` cannot check it.
 
-## Producing `vk.bin`
+## Producing the input files
 
-A binary file containing the 32 raw bytes of the SP1 program's verifying-key hash. This is what `sp1_sdk::HashableKey::bytes32_raw()` returns — see the [sp1-sdk docs](https://docs.rs/sp1-sdk) and the SP1 [getting-started guide](https://docs.succinct.xyz/) for setting up a prover client and `setup`-ing your ELF.
+### `vk.bin` (`gen --vkey`)
+
+A binary file containing the 32 raw bytes of `sp1_sdk::HashableKey::bytes32_raw()`:
 
 ```rust
-use sp1_sdk::{HashableKey, Prover, ProverClient, ProvingKey};
-
 let prover = ProverClient::from_env().await;
 let pk = prover.setup(MY_PROGRAM_ELF).await.unwrap();
 std::fs::write("vk.bin", pk.verifying_key().bytes32_raw()).unwrap();
 ```
 
-`setup` does not generate a proof — only deriving the verifying key — so this is fast even for large programs.
+`setup` does not generate a proof, so this is fast even for large programs.
+
+### Raw SP1 proof file (`validate-proof --proof`)
+
+The bincode artifact `SP1ProofWithPublicValues::save(...)` writes directly — no zkaleido wrapper. Either format the matching `::load(...)` accepts works (post-network or `ProofFromNetwork`). Must be `SP1ProofMode::Groth16`; other modes are rejected with a clear error.

--- a/pipeline/src/config.rs
+++ b/pipeline/src/config.rs
@@ -5,7 +5,7 @@ use ark_serialize::CanonicalSerialize;
 use serde_json::json;
 use sp1_verifier::{GROTH16_VK_BYTES, load_ark_groth16_verifying_key_from_bytes};
 
-use crate::proof::CompileTimeInputs;
+use crate::proof::{CompileTimeInputs, RunTimeInputs};
 
 pub fn write_compile_time_json(out_path: &Path, compile: &CompileTimeInputs) -> Result<()> {
     let ark_vk = load_ark_groth16_verifying_key_from_bytes(&GROTH16_VK_BYTES)
@@ -21,6 +21,17 @@ pub fn write_compile_time_json(out_path: &Path, compile: &CompileTimeInputs) -> 
         "exit_code": compile.exit_code,
         "vk_root": compile.vk_root,
         "proof_nonce": compile.proof_nonce,
+    });
+
+    fs::write(out_path, serde_json::to_vec_pretty(&json)?)
+        .with_context(|| format!("failed to write {:?}", out_path))?;
+    Ok(())
+}
+
+pub fn write_run_time_json(out_path: &Path, run: &RunTimeInputs) -> Result<()> {
+    let json = json!({
+        "groth16_proof": run.gnark_compressed_proof,
+        "raw_public_input": run.public_values,
     });
 
     fs::write(out_path, serde_json::to_vec_pretty(&json)?)

--- a/pipeline/src/main.rs
+++ b/pipeline/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod proof;
 mod run_dir;
+mod sp1_artifact;
 mod steps;
 
 use std::{
@@ -11,8 +12,11 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
+use proof::RunTimeInputs;
 use run_dir::{RunDir, StepTiming, cleanup_intermediates, update_latest_symlink, write_summary};
 use tracing::{error, info};
+
+const EXPECTED_PUBLIC_VALUES_LEN: usize = 36;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
@@ -24,6 +28,8 @@ struct Cli {
 #[derive(Subcommand, Debug)]
 enum Cmd {
     /// Generate a v5c boolean circuit from a 32-byte SP1 program vkey hash.
+    /// The resulting circuit is unvalidated; run `validate-proof` once a proof
+    /// is available to assert the verifier accepts it.
     Gen {
         /// Path to a binary file containing the 32-byte SP1 program vkey hash
         /// (the raw output of `sp1_sdk::HashableKey::bytes32_raw()`).
@@ -35,6 +41,24 @@ enum Cmd {
         /// Keep the v5a `g16.ckt` intermediate after success (default: delete it).
         #[arg(long)]
         keep_intermediate: bool,
+    },
+    /// Validate an existing v5c circuit against a raw SP1 v6 prover artifact
+    /// (bincode-encoded `SP1ProofWithPublicValues`, the file an SP1 prover emits
+    /// via `proof.save(...)`). Runs only the write-input-bits + cleartext-exec
+    /// stages — skips the expensive `g16gen generate` + `ckt-lvl prealloc`, so a
+    /// `--vkey`-generated circuit can be validated without regeneration. Writes
+    /// `inputs.txt` in the format `gobbletest exec` consumes, then runs the
+    /// cleartext-exec sanity check.
+    ValidateProof {
+        /// Path to the v5c circuit to validate.
+        #[arg(long)]
+        v5c: PathBuf,
+        /// Path to the raw SP1 v6 artifact (bincode `SP1ProofWithPublicValues`).
+        #[arg(long)]
+        proof: PathBuf,
+        /// Parent directory under which a timestamped run dir is created.
+        #[arg(long, env = "G16_VALIDATION_RUNS", default_value = "validation-runs")]
+        runs_dir: PathBuf,
     },
 }
 
@@ -49,6 +73,11 @@ async fn main() {
             runs_dir,
             keep_intermediate,
         } => run_gen(vkey, runs_dir, keep_intermediate).await,
+        Cmd::ValidateProof {
+            v5c,
+            proof,
+            runs_dir,
+        } => run_validate(v5c, proof, runs_dir).await,
     };
 
     if let Err(e) = result {
@@ -64,11 +93,7 @@ async fn run_gen(vkey_path: PathBuf, runs_dir: PathBuf, keep_intermediate: bool)
         .with_context(|| format!("failed to resolve --vkey {:?}", vkey_path))?;
     let source_label = vkey_path.display().to_string();
 
-    fs::create_dir_all(&runs_dir)
-        .with_context(|| format!("failed to create --runs-dir {:?}", runs_dir))?;
-    let runs_dir = fs::canonicalize(&runs_dir)
-        .with_context(|| format!("failed to resolve --runs-dir {:?}", runs_dir))?;
-
+    let runs_dir = prepare_runs_dir(&runs_dir)?;
     let run = RunDir::create(&runs_dir)?;
     info!(run_dir = ?run.root, "created run directory");
 
@@ -94,6 +119,43 @@ async fn run_gen(vkey_path: PathBuf, runs_dir: PathBuf, keep_intermediate: bool)
     update_latest_symlink(&runs_dir, &run)?;
 
     info!(v5c = ?run.v5c_ckt(), "pipeline completed");
+    Ok(())
+}
+
+async fn run_validate(v5c_path: PathBuf, proof_path: PathBuf, runs_dir: PathBuf) -> Result<()> {
+    let total_start = Instant::now();
+
+    let v5c_path = fs::canonicalize(&v5c_path)
+        .with_context(|| format!("failed to resolve --v5c {:?}", v5c_path))?;
+    let proof_path = fs::canonicalize(&proof_path)
+        .with_context(|| format!("failed to resolve --proof {:?}", proof_path))?;
+
+    let runs_dir = prepare_runs_dir(&runs_dir)?;
+    let run = RunDir::create(&runs_dir)?;
+    info!(run_dir = ?run.root, "created run directory");
+
+    let source_label = format!("v5c={}, proof={}", v5c_path.display(), proof_path.display());
+    let mut timings: Vec<StepTiming> = Vec::new();
+
+    let success = match drive_validate(&v5c_path, &proof_path, &run, &mut timings).await {
+        Ok(()) => true,
+        Err(e) => {
+            error!(error = %e, "validate failed");
+            let _ = write_summary(&run, &source_label, &timings, total_start.elapsed(), false);
+            return Err(e);
+        }
+    };
+
+    write_summary(
+        &run,
+        &source_label,
+        &timings,
+        total_start.elapsed(),
+        success,
+    )?;
+    update_latest_symlink(&runs_dir, &run)?;
+
+    info!(v5c = ?v5c_path, "validation passed");
     Ok(())
 }
 
@@ -146,4 +208,71 @@ async fn drive_gen(vkey_path: &Path, run: &RunDir, timings: &mut Vec<StepTiming>
     });
 
     Ok(())
+}
+
+async fn drive_validate(
+    v5c_path: &Path,
+    proof_path: &Path,
+    run: &RunDir,
+    timings: &mut Vec<StepTiming>,
+) -> Result<()> {
+    let run_time = sp1_artifact::load_runtime_from_sp1_artifact(proof_path)?;
+    check_pv_len(&run_time)?;
+
+    info!("step 1/2: g16gen write-input-bits");
+    step_write_input_bits(&run_time, run, timings)?;
+    info!("step 2/2: cleartext exec sanity check");
+    step_sanity_check(v5c_path, &run.inputs_txt(), timings).await?;
+
+    Ok(())
+}
+
+// ---- helpers shared by drive_gen and drive_validate ----
+
+fn check_pv_len(run_time: &RunTimeInputs) -> Result<()> {
+    if run_time.public_values.len() != EXPECTED_PUBLIC_VALUES_LEN {
+        bail!(
+            "public values length {} != {} expected by g16gen (hardcoded \
+             INPUT_MESSAGE_LEN at g16/g16gen/src/circuit_args.rs); this pipeline \
+             currently supports only 36-byte programs",
+            run_time.public_values.len(),
+            EXPECTED_PUBLIC_VALUES_LEN,
+        );
+    }
+    Ok(())
+}
+
+fn step_write_input_bits(
+    run_time: &RunTimeInputs,
+    run: &RunDir,
+    timings: &mut Vec<StepTiming>,
+) -> Result<()> {
+    config::write_run_time_json(&run.run_time_json(), run_time)?;
+    let t = Instant::now();
+    steps::run_g16gen("write-input-bits", &run.run_time_json(), &run.root)?;
+    if !run.inputs_txt().exists() {
+        bail!("g16gen produced no inputs.txt at {:?}", run.inputs_txt());
+    }
+    timings.push(StepTiming {
+        name: "g16gen-inputs",
+        duration: t.elapsed(),
+    });
+    Ok(())
+}
+
+async fn step_sanity_check(v5c: &Path, inputs: &Path, timings: &mut Vec<StepTiming>) -> Result<()> {
+    let t = Instant::now();
+    steps::sanity_check(v5c, inputs).await?;
+    timings.push(StepTiming {
+        name: "sanity-check",
+        duration: t.elapsed(),
+    });
+    Ok(())
+}
+
+fn prepare_runs_dir(runs_dir: &Path) -> Result<PathBuf> {
+    fs::create_dir_all(runs_dir)
+        .with_context(|| format!("failed to create --runs-dir {:?}", runs_dir))?;
+    fs::canonicalize(runs_dir)
+        .with_context(|| format!("failed to resolve --runs-dir {:?}", runs_dir))
 }

--- a/pipeline/src/proof.rs
+++ b/pipeline/src/proof.rs
@@ -4,9 +4,7 @@ use anyhow::{Context, Result, anyhow};
 use num_bigint::BigUint;
 use sp1_verifier::VK_ROOT_BYTES;
 
-/// SP1 v6 standard constants. Together with the program's vkey hash they fully
-/// determine the four public-input fields the verifier circuit folds into
-/// `vk.gamma_abc_g1[0]` at compile time.
+/// SP1 v6 standard constants (used when only a vkey hash is supplied).
 const SP1_V6_EXIT_CODE: &str = "0";
 const SP1_V6_PROOF_NONCE: &str = "0";
 
@@ -15,6 +13,11 @@ pub struct CompileTimeInputs {
     pub exit_code: String,
     pub vk_root: String,
     pub proof_nonce: String,
+}
+
+pub struct RunTimeInputs {
+    pub gnark_compressed_proof: Vec<u8>,
+    pub public_values: Vec<u8>,
 }
 
 pub fn load_from_vkey_file(path: &Path) -> Result<CompileTimeInputs> {

--- a/pipeline/src/run_dir.rs
+++ b/pipeline/src/run_dir.rs
@@ -26,12 +26,20 @@ impl RunDir {
         self.root.join("compile_time.json")
     }
 
+    pub fn run_time_json(&self) -> PathBuf {
+        self.root.join("run_time.json")
+    }
+
     pub fn v5a_ckt(&self) -> PathBuf {
         self.root.join("g16.ckt")
     }
 
     pub fn v5c_ckt(&self) -> PathBuf {
         self.root.join("v5c.ckt")
+    }
+
+    pub fn inputs_txt(&self) -> PathBuf {
+        self.root.join("inputs.txt")
     }
 
     pub fn summary_path(&self) -> PathBuf {
@@ -92,9 +100,5 @@ pub fn cleanup_intermediates(run: &RunDir, keep: bool) -> Result<()> {
         return Ok(());
     }
     let _ = fs::remove_file(run.v5a_ckt());
-    // g16gen writes these to its cwd (= run dir); they can be tens of GB and
-    // are not reused across runs.
-    let _ = fs::remove_file(run.root.join("fanout.cache"));
-    let _ = fs::remove_file(run.root.join("outputs.cache"));
     Ok(())
 }

--- a/pipeline/src/sp1_artifact.rs
+++ b/pipeline/src/sp1_artifact.rs
@@ -1,0 +1,96 @@
+//! Decoder for a raw SP1 v6 prover artifact (a bincode-serialized
+//! `SP1ProofWithPublicValues`, or its prover-network sibling `ProofFromNetwork`).
+//!
+//! We deliberately avoid depending on `sp1-sdk`: it would pull in ~200 crates
+//! (`sp1-prover`, `sp1-core-machine`, `sp1-recursion-*`, etc.) and force a
+//! `sp1-verifier 6.2.x` resolution that conflicts with the `=6.1.0` we pin
+//! elsewhere in this workspace. Instead, we mirror just enough of the bincode
+//! field layout to recover the Groth16 proof bytes and public values.
+
+use std::{fs::File, io::BufReader, path::Path};
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde::Deserialize;
+use zkaleido_sp1_groth16_verifier::Sp1Groth16Proof;
+
+use crate::proof::RunTimeInputs;
+
+/// `SP1Proof` is `#[derive(Serialize, Deserialize)]` with the default
+/// declaration order: `Core, Compressed, Plonk, Groth16`. Bincode encodes the
+/// variant as a little-endian `u32`, so Groth16 is tag 3.
+const SP1_PROOF_GROTH16_TAG: u32 = 3;
+
+/// Mirror of `sp1_verifier::Groth16Bn254Proof`. Bincode is positional, so field
+/// names are irrelevant — only the declaration order matters.
+#[allow(dead_code)]
+#[derive(Deserialize)]
+struct Groth16Bn254ProofMirror {
+    public_inputs: [String; 5],
+    /// This is the field `SP1ProofWithPublicValues::bytes()` uses to build
+    /// the on-chain proof blob — it's the prefix-tagged Groth16 proof bytes
+    /// (the form `Sp1Groth16Proof::parse` accepts), hex-encoded as a string.
+    encoded_proof: String,
+    raw_proof: String,
+    groth16_vkey_hash: [u8; 32],
+}
+
+/// Mirror of `sp1_primitives::types::Buffer`. `ptr` is `#[serde(skip)]`
+/// upstream, so the on-disk encoding is just `{ data: Vec<u8> }`.
+#[derive(Deserialize)]
+struct BufferMirror {
+    data: Vec<u8>,
+}
+
+/// Mirror of `sp1_primitives::io::SP1PublicValues`.
+#[derive(Deserialize)]
+struct SP1PublicValuesMirror {
+    buffer: BufferMirror,
+}
+
+/// Decode a raw SP1 v6 artifact at `path` and lift it into [`RunTimeInputs`].
+/// Errors loudly if the artifact is not a Groth16 proof.
+pub fn load_runtime_from_sp1_artifact(path: &Path) -> Result<RunTimeInputs> {
+    let file =
+        File::open(path).with_context(|| format!("failed to open SP1 artifact {:?}", path))?;
+    let mut reader = BufReader::new(file);
+
+    let tag: u32 = bincode::deserialize_from(&mut reader)
+        .with_context(|| format!("failed to read SP1Proof discriminant from {:?}", path))?;
+    if tag != SP1_PROOF_GROTH16_TAG {
+        let mode = match tag {
+            0 => "Core",
+            1 => "Compressed",
+            2 => "Plonk",
+            other => return Err(anyhow!("SP1Proof variant tag {other} is not a known mode")),
+        };
+        bail!(
+            "SP1 artifact {:?} is a {} proof; only Groth16 is supported",
+            path,
+            mode,
+        );
+    }
+
+    let groth16: Groth16Bn254ProofMirror = bincode::deserialize_from(&mut reader)
+        .with_context(|| format!("failed to decode Groth16Bn254Proof in {:?}", path))?;
+    let public_values: SP1PublicValuesMirror = bincode::deserialize_from(&mut reader)
+        .with_context(|| format!("failed to decode SP1PublicValues in {:?}", path))?;
+    // `sp1_version` and (for the post-network format) `tee_proof` trail this
+    // point; we don't need them.
+
+    // Reconstruct what `SP1ProofWithPublicValues::bytes()` returns for the
+    // Groth16 variant: the first 4 bytes of the groth16 vkey hash (used as the
+    // on-chain selector) followed by the hex-decoded encoded proof.
+    let encoded = hex::decode(&groth16.encoded_proof)
+        .context("failed to hex-decode Groth16 encoded_proof")?;
+    let mut proof_bytes = Vec::with_capacity(4 + encoded.len());
+    proof_bytes.extend_from_slice(&groth16.groth16_vkey_hash[..4]);
+    proof_bytes.extend_from_slice(&encoded);
+
+    let parsed = Sp1Groth16Proof::parse(&proof_bytes)
+        .map_err(|e| anyhow!("failed to parse SP1 Groth16 proof bytes: {e}"))?;
+
+    Ok(RunTimeInputs {
+        gnark_compressed_proof: parsed.proof.to_gnark_compressed_bytes().to_vec(),
+        public_values: public_values.buffer.data,
+    })
+}

--- a/pipeline/src/steps.rs
+++ b/pipeline/src/steps.rs
@@ -3,7 +3,7 @@ use std::{
     process::{Command, Stdio},
 };
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 
 fn g16_manifest() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -69,4 +69,30 @@ pub async fn verify(v5a: &Path) -> Result<bool> {
     } else {
         Ok(result.unwrap())
     }
+}
+
+pub async fn sanity_check(v5c: &Path, inputs: &Path) -> Result<()> {
+    let v5c_s = v5c
+        .to_str()
+        .context("v5c path is not valid UTF-8")?
+        .to_string();
+    let inputs_s = inputs
+        .to_str()
+        .context("inputs path is not valid UTF-8")?
+        .to_string();
+
+    let outputs = gobbletest::exec::exec(&v5c_s, &inputs_s).await;
+    if outputs.len() != 1 {
+        return Err(anyhow!(
+            "expected single output bit from verifier circuit, got {} bits: {:?}",
+            outputs.len(),
+            outputs
+        ));
+    }
+    if !outputs[0] {
+        return Err(anyhow!(
+            "verifier circuit rejected the proof (output bit = false)"
+        ));
+    }
+    Ok(())
 }


### PR DESCRIPTION
The PR adds execution of the circuit (v5c ckt) by taking a user supplied proof as input to the circuit. 

Earlier the pipeline has no command to validate a created circuit even when proof was available.