### PR TITLE
test: validate Montgomery constants in tests

### DIFF
--- a/g16ckt/src/gadgets/bn254/fq.rs
+++ b/g16ckt/src/gadgets/bn254/fq.rs
@@ -815,4 +815,9 @@ pub(super) mod tests {
             });
         assert_eq!(result.output_value.value, Fq::as_montgomery(expected_c));
     }
+
+    #[test]
+    fn test_montgomery_constants() {
+        assert!(Fq::validate_montgomery_constants());
+    }
 }


### PR DESCRIPTION
Adds a test to `Fq` that runs the `Fp254Impl` validator for Montgomery constants.

Closes #86.