### PR TITLE
test: ensure random field sampler exercises full range

### DIFF
--- a/g16ckt/src/gadgets/bn254/fq.rs
+++ b/g16ckt/src/gadgets/bn254/fq.rs
@@ -81,8 +81,11 @@ impl Fp254Impl for Fq {
 
 impl Fq {
     pub fn random(rng: &mut impl Rng) -> ark_bn254::Fq {
-        let bytes: [u8; 31] = rng.r#gen();
-        ark_bn254::Fq::from_random_bytes(&bytes).unwrap()
+        loop {
+            if let Some(bytes) = ark_bn254::Fq::from_random_bytes(&rng.r#gen::<[u8; 32]>()) {
+                return bytes;
+            }
+        }
     }
 
     pub fn new_constant(u: &ark_bn254::Fq) -> Result<Fq, Error> {

--- a/g16ckt/src/gadgets/bn254/fq.rs
+++ b/g16ckt/src/gadgets/bn254/fq.rs
@@ -3,7 +3,7 @@ use std::{
     str::FromStr,
 };
 
-use ark_ff::{Field, PrimeField};
+use ark_ff::{Field, PrimeField, UniformRand};
 use num_bigint::BigUint;
 use rand::Rng;
 
@@ -81,11 +81,7 @@ impl Fp254Impl for Fq {
 
 impl Fq {
     pub fn random(rng: &mut impl Rng) -> ark_bn254::Fq {
-        loop {
-            if let Some(bytes) = ark_bn254::Fq::from_random_bytes(&rng.r#gen::<[u8; 32]>()) {
-                return bytes;
-            }
-        }
+        ark_bn254::Fq::rand(rng)
     }
 
     pub fn new_constant(u: &ark_bn254::Fq) -> Result<Fq, Error> {

--- a/g16ckt/src/gadgets/bn254/fr.rs
+++ b/g16ckt/src/gadgets/bn254/fr.rs
@@ -138,17 +138,13 @@ impl Fr {
 
 #[cfg(test)]
 mod tests {
-    use ark_ff::Field;
-    use rand::{Rng, rngs::OsRng};
+    use ark_ff::UniformRand;
+    use rand::rngs::OsRng;
 
     use super::*;
 
     fn rnd() -> ark_bn254::Fr {
-        loop {
-            if let Some(bn) = ark_bn254::Fr::from_random_bytes(&OsRng.r#gen::<[u8; 32]>()) {
-                return bn;
-            }
-        }
+        ark_bn254::Fr::rand(&mut OsRng)
     }
 
     #[test]


### PR DESCRIPTION
The `Fq::random` test helper does not sample from the entire field range, excluding values from tests. This PR updates the helper to use rejection sampling against the entire range.

Closes #93.