### PR TITLE
feat: add checksum verification to `g16check`

### DIFF
--- a/g16check/src/main.rs
+++ b/g16check/src/main.rs
@@ -8,8 +8,7 @@ use indicatif::ProgressBar;
 async fn main() {
     let args: Vec<String> = std::env::args().collect();
     if args.len() != 2 {
-        eprintln!("Usage: g16check path_to_file.v5a");
-        return;
+        panic!("incorrect number of arguments: g16check path_to_file.v5a");
     }
     let path = args[1].clone();
 

--- a/g16check/src/main.rs
+++ b/g16check/src/main.rs
@@ -1,12 +1,17 @@
 use ahash::{HashMap, HashMapExt, HashSet};
-use ckt_fmtv5_types::v5::a::reader::CircuitReaderV5a;
+use ckt_fmtv5_types::v5::a::reader::{CircuitReaderV5a, verify_v5a_checksum};
 use cynosure::hints::unlikely;
 use fixedbitset::FixedBitSet;
 use indicatif::ProgressBar;
 
 #[monoio::main]
 async fn main() {
-    let mut reader = CircuitReaderV5a::open("/home/user/g16.ckt").unwrap();
+    let path = "/Users/aaron/Documents/GitHub/g16/g16.ckt"; // TODO: don't hardcode this
+    assert!(
+        verify_v5a_checksum(path).await.unwrap(),
+        "checksum verification failed"
+    );
+    let mut reader = CircuitReaderV5a::open(path).unwrap();
     let mut available_wires = FixedBitSet::with_capacity(2usize.pow(34));
     for i in 0..reader.header().primary_inputs + 2 {
         available_wires.insert(i as usize);

--- a/g16check/src/main.rs
+++ b/g16check/src/main.rs
@@ -6,9 +6,15 @@ use indicatif::ProgressBar;
 
 #[monoio::main]
 async fn main() {
-    let path = "/Users/aaron/Documents/GitHub/g16/g16.ckt"; // TODO: don't hardcode this
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Usage: g16check path_to_file.v5a");
+        return;
+    }
+    let path = args[1].clone();
+
     assert!(
-        verify_v5a_checksum(path).await.unwrap(),
+        verify_v5a_checksum(path.clone()).await.unwrap(),
         "checksum verification failed"
     );
     let mut reader = CircuitReaderV5a::open(path).unwrap();


### PR DESCRIPTION
The `g16check` tool does not verify the input file checksum. This PR adds this check, and removes the existing hardcoded file path.

Closes #99.