### PR TITLE
fix: retype diagnostic gate counter

### DIFF
--- a/g16check/src/main.rs
+++ b/g16check/src/main.rs
@@ -13,7 +13,7 @@ async fn main() {
     }
     let pb = ProgressBar::new(reader.header().total_gates());
     let mut wire_map = HashMap::new();
-    let mut cur = 0;
+    let mut cur: u64 = 0;
     let always_available = reader.header().primary_inputs + 2;
     let outputs = reader.outputs().iter().copied().collect::<HashSet<_>>();
 


### PR DESCRIPTION
A `g16check` diagnostic gate counter can overflow with typical circuits, rendering diagnostic output inaccurate.

This PR retypes the counter to `u64` in order to mitigate this.

Closes #101.