### PR TITLE
feat: remove hardcoded `verify` path

### DIFF
--- a/verify/src/main.rs
+++ b/verify/src/main.rs
@@ -4,8 +4,10 @@ use ckt_fmtv5_types::v5::a::reader::verify_v5a_checksum;
 async fn main() {
     let args: Vec<String> = std::env::args().collect();
     if args.len() != 2 {
-        eprintln!("Usage: verify path_to_file.v5a");
-        return;
+        panic!("incorrect number of arguments: verify path_to_file.v5a");
     }
-    assert!(verify_v5a_checksum(args[1].clone()).await.unwrap())
+    assert!(
+        verify_v5a_checksum(args[1].clone()).await.unwrap(),
+        "checksum verification failed"
+    );
 }

--- a/verify/src/main.rs
+++ b/verify/src/main.rs
@@ -2,5 +2,10 @@ use ckt_fmtv5_types::v5::a::reader::verify_v5a_checksum;
 
 #[monoio::main]
 async fn main() {
-    assert!(verify_v5a_checksum("g16.ckt").await.unwrap())
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Usage: verify path_to_file.v5a");
+        return;
+    }
+    assert!(verify_v5a_checksum(args[1].clone()).await.unwrap())
 }


### PR DESCRIPTION
The `verify` tool uses a hardcoded input file path. This PR allows the user to supply the path.

Addresses part of #82.