### PR TITLE
docs: improve `G2` documentation

### DIFF
--- a/g16ckt/src/gadgets/bn254/g2.rs
+++ b/g16ckt/src/gadgets/bn254/g2.rs
@@ -489,6 +489,8 @@ impl G2Projective {
     }
 
     /// Deserialize into G2Projective from its 64 byte serialized bit representation.
+    /// NOTE: This does not perform a prime-order subgroup check!
+    /// This is fine for the Groth16 use case, since we handle this elsewhere.
     // Follows arkworks implementation here:
     // https://github.com/arkworks-rs/algebra/blob/v0.5.0/ec/src/models/short_weierstrass/mod.rs#L145
     pub fn deserialize_checked<C: CircuitContext>(

--- a/g16ckt/src/gadgets/bn254/g2.rs
+++ b/g16ckt/src/gadgets/bn254/g2.rs
@@ -490,7 +490,7 @@ impl G2Projective {
 
     /// Deserialize into G2Projective from its 64 byte serialized bit representation.
     /// NOTE: This does not perform a prime-order subgroup check!
-    /// This is fine for the Groth16 use case, since we handle this elsewhere.
+    /// This is fine for the Groth16 use case: the G2 subgroup check on the proof's `b` point is performed inside the pairing, in `ell_coeffs_montgomery` (see `bn254::pairing`), and folded into the final verification result by `groth16_verify`.
     // Follows arkworks implementation here:
     // https://github.com/arkworks-rs/algebra/blob/v0.5.0/ec/src/models/short_weierstrass/mod.rs#L145
     pub fn deserialize_checked<C: CircuitContext>(


### PR DESCRIPTION
The documentation for `G2` deserialization does not specify that there is no prime-order subgroup check. This is fine for our implementation, but could be problematic if used elsewhere.

This PR updates the documentation to make this clear.

Closes #110.