### PR TITLE
chore: pin ckt to version v0.3.0-rc2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ dependencies = [
 [[package]]
 name = "ckt-fmtv5-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/ckt#a3683426d73af89e136725b0f8957f073f67cc1b"
+source = "git+https://github.com/alpenlabs/ckt?tag=v0.3.0-rc.2#a7462a1d1372f5dbf0519c61b39a2f032898edff"
 dependencies = [
  "blake3",
  "cynosure",
@@ -646,7 +646,7 @@ dependencies = [
 [[package]]
 name = "ckt-lvl"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/ckt#a3683426d73af89e136725b0f8957f073f67cc1b"
+source = "git+https://github.com/alpenlabs/ckt?tag=v0.3.0-rc.2#a7462a1d1372f5dbf0519c61b39a2f032898edff"
 dependencies = [
  "ahash",
  "ckt-fmtv5-types",

--- a/g16check/Cargo.toml
+++ b/g16check/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 monoio = { version = "0.2.4", features = ["sync"] }
-ckt-fmtv5-types = { git = "https://github.com/alpenlabs/ckt", features = ["v5"] }
+ckt-fmtv5-types = { git = "https://github.com/alpenlabs/ckt", tag = "v0.3.0-rc.2", features = ["v5"] }
 indicatif = "0.18.0"
 cynosure = { version = "0.3.0", default-features = false, features = ["hints"] }
 fixedbitset = "0.5.7"

--- a/g16gen/Cargo.toml
+++ b/g16gen/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2024"
 
 [dependencies]
 ahash = "0.8.12"
-ckt-fmtv5-types = { git = "https://github.com/alpenlabs/ckt", features = ["v5"] }
+ckt-fmtv5-types = { git = "https://github.com/alpenlabs/ckt", tag = "v0.3.0-rc.2", features = ["v5"] }
 indicatif = "0.18.0"
-ckt-lvl = { git = "https://github.com/alpenlabs/ckt" }
+ckt-lvl = { git = "https://github.com/alpenlabs/ckt", tag = "v0.3.0-rc.2" }
 g16ckt = { path = "../g16ckt" }
 tracing = "0.1.41"
 rand = "0.8" # using old version for consistency with ark

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -10,8 +10,8 @@ path = "src/main.rs"
 [dependencies]
 sp1-verifier = { version = "=6.2.0", features = ["ark"] }
 
-ckt-fmtv5-types = { git = "https://github.com/alpenlabs/ckt", features = ["v5"] }
-ckt-lvl = { git = "https://github.com/alpenlabs/ckt" }
+ckt-fmtv5-types = { git = "https://github.com/alpenlabs/ckt", tag = "v0.3.0-rc.2", features = ["v5"] }
+ckt-lvl = { git = "https://github.com/alpenlabs/ckt", tag = "v0.3.0-rc.2" }
 
 ark-serialize = "0.5.0"
 

--- a/verify/Cargo.toml
+++ b/verify/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ckt-fmtv5-types = { git = "https://github.com/alpenlabs/ckt", features = ["v5"] }
+ckt-fmtv5-types = { git = "https://github.com/alpenlabs/ckt", tag = "v0.3.0-rc.2", features = ["v5"] }
 monoio = { version = "0.2.4", features = ["sync"] }


### PR DESCRIPTION
This PR fixes all ckt dependencies to version v0.3.0-rc.2. 