### PR TITLE
docs: add documentation for `g16check` and `verify`

### DIFF
--- a/g16check/README.md
+++ b/g16check/README.md
@@ -1,0 +1,9 @@
+# g16check - Validate `v5a` wire lifetimes
+
+This tool takes a `v5a` circuit file and parses it, validating wire lifetimes.
+Before doing this, it also verifies the file's checksum to ensure it hasn't been corrupted.
+
+To use from the `g16` workspace:
+```sh
+cargo run -p g16check --release -- /path/to/circuit.v5a
+```

--- a/verify/README.md
+++ b/verify/README.md
@@ -1,0 +1,12 @@
+# verify - Check a circuit file against an SP1 key
+
+This tool takes a circuit file and checks it against a supplied SP1 verification key.
+
+Given a `v5c` circuit file and SP1 verification key, it:
+- Checks that the supplied key matches the key embedded into the circuit file header
+- Validates the circuit file checksum
+
+To use from the `g16` workspace:
+```sh
+cargo run -p verify --release -- /path/to/circuit.v5c /path/to/sp1_vk.bin
+```


### PR DESCRIPTION
Adds basic usage documentation for `g16check` and `verify`.

Closes #82.