### PR TITLE
chore: remove unused debug code

### DIFF
--- a/g16gen/src/modes/fanout_ctr.rs
+++ b/g16gen/src/modes/fanout_ctr.rs
@@ -10,7 +10,6 @@ pub struct FanoutCounter {
     fanout: Option<Vec<u32>>, // Original -> Normalized IDs
     next_normalized_id: u64,
     primary_inputs: usize,
-    biggest_fanout_seen: usize,
     spinner: ProgressBar,
 }
 
@@ -171,7 +170,6 @@ impl FanoutCounter {
             fanout: Some(Vec::new()),
             next_normalized_id: 0,
             primary_inputs,
-            biggest_fanout_seen: 0,
             spinner: pb,
         };
 
@@ -198,8 +196,7 @@ impl FanoutCounter {
         fanout[wire_id]
     }
 
-    pub fn finish(&mut self) -> (Vec<u32>, usize) {
-        let fanout = self.fanout.take().unwrap();
-        (fanout, self.biggest_fanout_seen)
+    pub fn finish(&mut self) -> Vec<u32> {
+        self.fanout.take().unwrap()
     }
 }

--- a/g16gen/src/passes/credits.rs
+++ b/g16gen/src/passes/credits.rs
@@ -44,8 +44,7 @@ pub fn run_credits_pass<const N: usize>(
     };
     println!("Output wires: {:?}", real_output_wires);
 
-    let (mut fanout, biggest_credits_seen) = ctx.get_mut_mode().unwrap().finish();
-    println!("Biggest credits seen: {}", biggest_credits_seen);
+    let mut fanout = ctx.get_mut_mode().unwrap().finish();
     let elapsed_credits = credits_start.elapsed();
     info!(
         "Completed credits pass ({} wires) in {:?}",


### PR DESCRIPTION
Removes unused debug code.

Closes #77.